### PR TITLE
Add CsToml.Extensions.Configuration

### DIFF
--- a/CsToml.sln
+++ b/CsToml.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsToml.Extensions", "src\Cs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsToml.Extensions.Configuration", "src\CsToml.Extensions.Configuration\CsToml.Extensions.Configuration.csproj", "{57977698-C9B4-4525-85CF-4ADE3859C920}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsToml.Extensions.Configuration.Tests", "tests\CsToml.Extensions.Configuration.Tests\CsToml.Extensions.Configuration.Tests.csproj", "{F7D81327-0320-455D-B1EB-D64E3901752E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,10 @@ Global
 		{57977698-C9B4-4525-85CF-4ADE3859C920}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57977698-C9B4-4525-85CF-4ADE3859C920}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{57977698-C9B4-4525-85CF-4ADE3859C920}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7D81327-0320-455D-B1EB-D64E3901752E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7D81327-0320-455D-B1EB-D64E3901752E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7D81327-0320-455D-B1EB-D64E3901752E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7D81327-0320-455D-B1EB-D64E3901752E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -76,6 +82,7 @@ Global
 		{9AEBDFED-E0B9-4C1D-94BE-B2D185DD1A2A} = {D1DA58D2-DF19-442A-B61A-BE8A473DE878}
 		{CCCC9670-6422-4583-BDC5-74D475D858A0} = {A9C74E56-F4CF-45C0-8DD4-AEF20E74E454}
 		{57977698-C9B4-4525-85CF-4ADE3859C920} = {A9C74E56-F4CF-45C0-8DD4-AEF20E74E454}
+		{F7D81327-0320-455D-B1EB-D64E3901752E} = {D1DA58D2-DF19-442A-B61A-BE8A473DE878}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D2BE6D04-CA64-4762-A4A8-413B4115D763}

--- a/CsToml.sln
+++ b/CsToml.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CsToml.Generator.Tests", "t
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsToml.Extensions", "src\CsToml.Extensions\CsToml.Extensions.csproj", "{CCCC9670-6422-4583-BDC5-74D475D858A0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsToml.Extensions.Configuration", "src\CsToml.Extensions.Configuration\CsToml.Extensions.Configuration.csproj", "{57977698-C9B4-4525-85CF-4ADE3859C920}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{CCCC9670-6422-4583-BDC5-74D475D858A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CCCC9670-6422-4583-BDC5-74D475D858A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CCCC9670-6422-4583-BDC5-74D475D858A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57977698-C9B4-4525-85CF-4ADE3859C920}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57977698-C9B4-4525-85CF-4ADE3859C920}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57977698-C9B4-4525-85CF-4ADE3859C920}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57977698-C9B4-4525-85CF-4ADE3859C920}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -69,6 +75,7 @@ Global
 		{1F890883-85D7-4A5A-9FF2-9355367F455F} = {A9C74E56-F4CF-45C0-8DD4-AEF20E74E454}
 		{9AEBDFED-E0B9-4C1D-94BE-B2D185DD1A2A} = {D1DA58D2-DF19-442A-B61A-BE8A473DE878}
 		{CCCC9670-6422-4583-BDC5-74D475D858A0} = {A9C74E56-F4CF-45C0-8DD4-AEF20E74E454}
+		{57977698-C9B4-4525-85CF-4ADE3859C920} = {A9C74E56-F4CF-45C0-8DD4-AEF20E74E454}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D2BE6D04-CA64-4762-A4A8-413B4115D763}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Table of Contents
 * [Serialize and deserialize TOML values only](#serialize-and-deserialize-toml-values-only)
 * [TomlDocument class](#tomldocument-class)
 * [Extensions (CsToml.Extensions)](#extensions-cstomlextensions)
+* [Microsoft.Extensions.Configuration extensions (CsToml.Extensions.Configuration)](#microsoftextensionsconfiguration-extensions-cstomlextensionsconfiguration)
 * [UnitTest](#unittest)
 * [License](#license)
 
@@ -60,9 +61,13 @@ However, this requires Roslyn 4.3.1 (Visual Studio 2022 version 17.3) or higher.
 
 > PM> Install-Package [CsToml.Generator](https://www.nuget.org/packages/CsToml.Generator/)  
 
-Additional features are available by installing optional documents.(learn more in our [Extensions (CsToml.Extensions)](#extensions-cstomlextensions))
+If `CsToml.Extensions` is installed, you can serialize/deserialize from the TOML file path. learn more in our [Extensions (CsToml.Extensions)](#extensions-cstomlextensions)
 
 > PM> Install-Package [CsToml.Extensions](https://www.nuget.org/packages/CsToml.Extensions/)  
+
+If `CsToml.Extensions.Configuration` is installed, the TOML configuration provider is available. learn more in our [Microsoft.Extensions.Configuration extensions (CsToml.Extensions.Configuration)](#microsoftextensionsconfiguration-extensions-cstomlextensionsconfiguration)
+
+> PM> Install-Package [CsToml.Extensions.Configuration](https://www.nuget.org/packages/CsToml.Extensions.Configuration/)  
 
 Serialize and deserialize TOML sequence (Parse TOML sequence)
 ---
@@ -721,6 +726,35 @@ await CsTomlFileSerializer.SerializeAsync("test.toml", document);
 `CsTomlFileSerializer.Serialize` and `CsTomlFileSerializer.SerializeAsync` serialize the UTF8 string of `TomlDocument` to the TOML file.  
 
 `CsToml.Extensions` uses [Cysharp/NativeMemoryArray](https://github.com/Cysharp/NativeMemoryArray) as a third party library.
+
+Microsoft.Extensions.Configuration extensions (`CsToml.Extensions.Configuration`)
+---
+
+`CsToml.Extensions.Configuration` provides a configuration provider for `Microsoft.Extensions.Configuration` that reads TOML files or streams. Basically, the usage and options are the same as for [File configuration provider in .NET](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#json-configuration-provider).
+
+```csharp
+namespace CsToml.Extensions.Configuration;
+
+// ConfigurationBuilder
+var conf = new ConfigurationBuilder().AddTomlFile("test.toml").Build();
+
+// Blazor Web App 
+var builder = WebApplication.CreateBuilder(args);
+builder.Configuration.AddTomlFile("test.toml");
+var app = builder.Build();
+
+using var fs = new FileStream("test.toml", FileMode.Open);
+builder.Configuration.AddTomlStream(fs);
+```
+
+```csharp
+public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path);
+public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path, bool optional);
+public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange);
+public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, Microsoft.Extensions.FileProviders.IFileProvider? provider, string path, bool optional, bool reloadOnChange);
+public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, Action<TomlFileConfigurationSource> configureSource);
+public static IConfigurationBuilder AddTomlStream(this IConfigurationBuilder builder, System.IO.Stream stream);
+```
 
 UnitTest
 ---

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This library is distributed via NuGet. We target .NET 8 and .NET 9.
 
 > PM> Install-Package [CsToml](https://www.nuget.org/packages/CsToml/)
 
-When you install `CsToml.Generator`, it automatically creates code to make your custom classes serializable.(learn more in our [Serialize and deserialize custom classes (CsToml.Generator)](#serialize-and-deserialize-custom-classes-cstomlgenerator)). It is basically recommended to install it together with CsToml.  
+When you install `CsToml.Generator`, it automatically creates code to make your custom classes serializable. learn more in our [Serialize and deserialize custom class/struct/record/record struct (CsToml.Generator)](#serialize-and-deserialize-custom-classstructrecordrecord-struct-cstomlgenerator). It is basically recommended to install it together with CsToml.  
 However, this requires Roslyn 4.3.1 (Visual Studio 2022 version 17.3) or higher.
 
 > PM> Install-Package [CsToml.Generator](https://www.nuget.org/packages/CsToml.Generator/)  
@@ -730,7 +730,7 @@ await CsTomlFileSerializer.SerializeAsync("test.toml", document);
 Microsoft.Extensions.Configuration extensions (`CsToml.Extensions.Configuration`)
 ---
 
-`CsToml.Extensions.Configuration` provides a configuration provider for `Microsoft.Extensions.Configuration` that reads TOML files or streams. Basically, the usage and options are the same as for [File configuration provider in .NET](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#json-configuration-provider).
+`CsToml.Extensions.Configuration` provides a configuration provider for `Microsoft.Extensions.Configuration` that reads TOML files or streams. Basically, the usage and options are the same as for [File configuration provider in .NET](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers).
 
 ```csharp
 namespace CsToml.Extensions.Configuration;

--- a/src/CsToml.Extensions.Configuration/CsToml.Extensions.Configuration.csproj
+++ b/src/CsToml.Extensions.Configuration/CsToml.Extensions.Configuration.csproj
@@ -1,17 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
+  <Import Project="../NuGet.props" />
+  
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Authors>prozolic</Authors>
     <Description>Microsoft.Extensions.Configuration extensions using CsToml.</Description>
-    <Copyright>prozolic</Copyright>
-    <PackageProjectUrl>https://github.com/prozolic/CsToml</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>TOML,serializer,parser,writer,reader,configuration</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <VersionPrefix>1.3.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CsToml.Extensions.Configuration/CsToml.Extensions.Configuration.csproj
+++ b/src/CsToml.Extensions.Configuration/CsToml.Extensions.Configuration.csproj
@@ -15,7 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/CsToml.Extensions.Configuration/CsToml.Extensions.Configuration.csproj
+++ b/src/CsToml.Extensions.Configuration/CsToml.Extensions.Configuration.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Authors>prozolic</Authors>
+    <Description>Microsoft.Extensions.Configuration extensions using CsToml.</Description>
+    <Copyright>prozolic</Copyright>
+    <PackageProjectUrl>https://github.com/prozolic/CsToml</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>TOML,serializer,parser,writer,reader,configuration</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <VersionPrefix>1.3.0</VersionPrefix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CsToml\CsToml.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CsToml.Extensions.Configuration/TomlConfigurationExtensions.cs
+++ b/src/CsToml.Extensions.Configuration/TomlConfigurationExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace CsToml.Extensions.Configuration;
+
+public static class TomlConfigurationExtensions
+{
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path)
+        => AddTomlFile(builder, provider: null, path: path, optional: false, reloadOnChange: false);
+
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path, bool optional)
+        => AddTomlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: false);
+
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, string path, bool optional, bool reloadOnChange)
+        => AddTomlFile(builder, provider: null, path: path, optional: optional, reloadOnChange: reloadOnChange);
+
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, Microsoft.Extensions.FileProviders.IFileProvider? provider, string path, bool optional, bool reloadOnChange)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.AddTomlFile((c) =>
+        {
+            c.FileProvider = provider;
+            c.Path = path;
+            c.Optional = optional;
+            c.ReloadOnChange = reloadOnChange;
+            c.ResolveFileProvider();
+        });
+    }
+
+    public static IConfigurationBuilder AddTomlFile(this IConfigurationBuilder builder, Action<TomlFileConfigurationSource> configureSource)
+    {
+        return builder.Add(configureSource);
+    }
+}

--- a/src/CsToml.Extensions.Configuration/TomlConfigurationExtensions.cs
+++ b/src/CsToml.Extensions.Configuration/TomlConfigurationExtensions.cs
@@ -31,4 +31,11 @@ public static class TomlConfigurationExtensions
     {
         return builder.Add(configureSource);
     }
+
+    public static IConfigurationBuilder AddTomlStream(this IConfigurationBuilder builder, System.IO.Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.Add<TomlStreamConfigurationSource>(s => s.Stream = stream);
+    }
 }

--- a/src/CsToml.Extensions.Configuration/TomlFileConfigurationParser.cs
+++ b/src/CsToml.Extensions.Configuration/TomlFileConfigurationParser.cs
@@ -1,0 +1,93 @@
+﻿using CsToml.Values;
+using Microsoft.Extensions.Configuration;
+
+namespace CsToml.Extensions.Configuration;
+
+internal sealed class TomlFileConfigurationParser
+{
+    private IDictionary<string, string?> data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    private readonly Stack<string> paths = new();
+    private bool isEmpty;
+
+    public IDictionary<string, string?> Parse(Stream stream)
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(stream);
+        VisitObjectElement(document.RootNode);
+        return data;
+    }
+
+    private void VisitObjectElement(TomlDocumentNode node)
+    {
+        isEmpty = true;
+        foreach (var element in node.GetNodeEnumerator())
+        {
+            isEmpty = false;
+            EnterContext(element.Key.ToString()!);
+            VisitElement(element.Value);
+            ExitContext();
+        }
+
+        if (paths.Count > 0 && isEmpty)
+        {
+            data[paths.Peek()] = null;
+        }
+    }
+
+    private void VisitElement(TomlDocumentNode node)
+    {
+        if (node.HasNodeOnly)
+        {
+            VisitObjectElement(node);
+            return;
+        }
+        else if (node.CanGetValue(TomlValueFeature.Array))
+        {
+            VisitArrayElement(node);
+            return;
+        }
+        else if (node.CanGetValue(TomlValueFeature.Table | TomlValueFeature.InlineTable))
+        {
+            VisitObjectElement(node);
+            return;
+        }
+        else if (node.HasValue)
+        {
+            var key = paths.Peek();
+            if (data.ContainsKey(key))
+            {
+                throw new FormatException();
+            }
+            if (node.GetString().Equals("∞"))
+            {
+
+            }
+            data[key] = node.GetString();
+        }
+    }
+
+    private void VisitArrayElement(TomlDocumentNode node)
+    {
+        int index = 0;
+
+        foreach (var arrayElement in node.GetArray())
+        {
+            EnterContext(index.ToString());
+            VisitElement(new TomlDocumentNode(arrayElement));
+            ExitContext();
+            index++;
+        }
+
+        if (paths.Count > 0 && index == 0)
+        {
+            data[paths.Peek()] = null;
+        }
+    }
+
+    private void EnterContext(string context)
+        => paths.Push(paths.Count > 0 ? paths.Peek() + ConfigurationPath.KeyDelimiter + context : context);
+
+    private void ExitContext()
+        => paths.Pop();
+}
+
+

--- a/src/CsToml.Extensions.Configuration/TomlFileConfigurationProvider.cs
+++ b/src/CsToml.Extensions.Configuration/TomlFileConfigurationProvider.cs
@@ -3,13 +3,10 @@ using Microsoft.Extensions.Configuration;
 
 namespace CsToml.Extensions.Configuration;
 
-internal sealed class TomlFileConfigurationProvider(FileConfigurationSource source) : FileConfigurationProvider(source)
+public class TomlFileConfigurationProvider(FileConfigurationSource source) : FileConfigurationProvider(source)
 {
     public override void Load(Stream stream)
     {
-        Span<byte> s = stackalloc byte[100];
-        var ss = stream.Read(s);
-        stream.Seek(0, SeekOrigin.Begin);
         Data = new TomlFileConfigurationParser().Parse(stream);
     }
 }

--- a/src/CsToml.Extensions.Configuration/TomlFileConfigurationProvider.cs
+++ b/src/CsToml.Extensions.Configuration/TomlFileConfigurationProvider.cs
@@ -1,0 +1,15 @@
+﻿using CsToml.Error;
+using Microsoft.Extensions.Configuration;
+
+namespace CsToml.Extensions.Configuration;
+
+internal sealed class TomlFileConfigurationProvider(FileConfigurationSource source) : FileConfigurationProvider(source)
+{
+    public override void Load(Stream stream)
+    {
+        Span<byte> s = stackalloc byte[100];
+        var ss = stream.Read(s);
+        stream.Seek(0, SeekOrigin.Begin);
+        Data = new TomlFileConfigurationParser().Parse(stream);
+    }
+}

--- a/src/CsToml.Extensions.Configuration/TomlFileConfigurationProvider.cs
+++ b/src/CsToml.Extensions.Configuration/TomlFileConfigurationProvider.cs
@@ -1,5 +1,4 @@
-﻿using CsToml.Error;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 
 namespace CsToml.Extensions.Configuration;
 
@@ -7,6 +6,6 @@ public class TomlFileConfigurationProvider(FileConfigurationSource source) : Fil
 {
     public override void Load(Stream stream)
     {
-        Data = new TomlFileConfigurationParser().Parse(stream);
+        Data = new TomlStreamConfigurationParser().Parse(stream);
     }
 }

--- a/src/CsToml.Extensions.Configuration/TomlFileConfigurationSource.cs
+++ b/src/CsToml.Extensions.Configuration/TomlFileConfigurationSource.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace CsToml.Extensions.Configuration;
+
+public sealed class TomlFileConfigurationSource : FileConfigurationSource
+{
+    public override IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        EnsureDefaults(builder);
+        return new TomlFileConfigurationProvider(this);
+    }
+}

--- a/src/CsToml.Extensions.Configuration/TomlStreamConfigurationParser.cs
+++ b/src/CsToml.Extensions.Configuration/TomlStreamConfigurationParser.cs
@@ -22,7 +22,7 @@ internal sealed class TomlStreamConfigurationParser
         foreach (var element in node.GetNodeEnumerator())
         {
             isEmpty = false;
-            EnterContext(element.Key.ToString()!);
+            EnterContext(element.Key.GetString()!);
             VisitElement(element.Value);
             ExitContext();
         }

--- a/src/CsToml.Extensions.Configuration/TomlStreamConfigurationParser.cs
+++ b/src/CsToml.Extensions.Configuration/TomlStreamConfigurationParser.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace CsToml.Extensions.Configuration;
 
-internal sealed class TomlFileConfigurationParser
+internal sealed class TomlStreamConfigurationParser
 {
     private IDictionary<string, string?> data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
     private readonly Stack<string> paths = new();
@@ -56,10 +56,6 @@ internal sealed class TomlFileConfigurationParser
             if (data.ContainsKey(key))
             {
                 throw new FormatException();
-            }
-            if (node.GetString().Equals("∞"))
-            {
-
             }
             data[key] = node.GetString();
         }

--- a/src/CsToml.Extensions.Configuration/TomlStreamConfigurationProvider.cs
+++ b/src/CsToml.Extensions.Configuration/TomlStreamConfigurationProvider.cs
@@ -6,6 +6,6 @@ public class TomlStreamConfigurationProvider(TomlStreamConfigurationSource sourc
 {
     public override void Load(Stream stream)
     {
-        Data = new TomlFileConfigurationParser().Parse(stream);
+        Data = new TomlStreamConfigurationParser().Parse(stream);
     }
 }

--- a/src/CsToml.Extensions.Configuration/TomlStreamConfigurationProvider.cs
+++ b/src/CsToml.Extensions.Configuration/TomlStreamConfigurationProvider.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace CsToml.Extensions.Configuration;
+
+public class TomlStreamConfigurationProvider(TomlStreamConfigurationSource source) : StreamConfigurationProvider(source)
+{
+    public override void Load(Stream stream)
+    {
+        Data = new TomlFileConfigurationParser().Parse(stream);
+    }
+}

--- a/src/CsToml.Extensions.Configuration/TomlStreamConfigurationSource.cs
+++ b/src/CsToml.Extensions.Configuration/TomlStreamConfigurationSource.cs
@@ -2,11 +2,8 @@
 
 namespace CsToml.Extensions.Configuration;
 
-public class TomlFileConfigurationSource : FileConfigurationSource
+public class TomlStreamConfigurationSource : StreamConfigurationSource
 {
     public override IConfigurationProvider Build(IConfigurationBuilder builder)
-    {
-        EnsureDefaults(builder);
-        return new TomlFileConfigurationProvider(this);
-    }
+        => new TomlStreamConfigurationProvider(this);
 }

--- a/src/CsToml.Extensions/CsToml.Extensions.csproj
+++ b/src/CsToml.Extensions/CsToml.Extensions.csproj
@@ -1,17 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../NuGet.props" />
+
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Authors>prozolic</Authors>
     <Description>Extensions to CsToml.</Description>
-    <Copyright>prozolic</Copyright>
-    <PackageProjectUrl>https://github.com/prozolic/CsToml</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>TOML,serializer,parser,writer,reader</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <VersionPrefix>1.3.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CsToml.Extensions/CsTomlFileSerializer.cs
+++ b/src/CsToml.Extensions/CsTomlFileSerializer.cs
@@ -28,8 +28,7 @@ public partial class CsTomlFileSerializer
             var readCount = RandomAccess.Read(handle, bytesSpan, 0);
 
             // check BOM
-            var startIndex = Utf8Helper.ContainBOM(bytesSpan) ? 3 : 0;
-            var tomlByteSpan = bytesSpan.Slice(startIndex, readCount - startIndex);
+            var tomlByteSpan = bytesSpan.Slice(0, readCount);
             return CsTomlSerializer.Deserialize<T>(tomlByteSpan, options);
         }
         else
@@ -40,9 +39,7 @@ public partial class CsTomlFileSerializer
 
             // check BOM
             var memory = tomlMemories[0];
-            var startIndex = Utf8Helper.ContainBOM(memory.Span) ? 3 : 0;
-
-            var startSegment = new ByteSequenceSegment(memory[startIndex..]);
+            var startSegment = new ByteSequenceSegment(memory);
             startSegment.SetRunningIndex(0);
             startSegment.SetNext(null);
 
@@ -76,8 +73,7 @@ public partial class CsTomlFileSerializer
             var byteMemories = bytes.AsMemory();
             var readCount = await RandomAccess.ReadAsync(handle, byteMemories, 0, cancellationToken).ConfigureAwait(configureAwait);
 
-            var startIndex = Utf8Helper.ContainBOM(byteMemories.Span) ? 3 : 0;
-            return CsTomlSerializer.Deserialize<T>(byteMemories.Span.Slice(startIndex, readCount - startIndex), options);
+            return CsTomlSerializer.Deserialize<T>(byteMemories.Span.Slice(0, readCount), options);
         }
         else
         {
@@ -87,9 +83,7 @@ public partial class CsTomlFileSerializer
 
             // check BOM
             var memory = tomlMemories[0];
-            var startIndex = Utf8Helper.ContainBOM(memory.Span) ? 3 : 0;
-
-            var startSegment = new ByteSequenceSegment(memory[startIndex..]);
+            var startSegment = new ByteSequenceSegment(memory);
             startSegment.SetRunningIndex(0);
             startSegment.SetNext(null);
 

--- a/src/CsToml.Generator/CsToml.Generator.csproj
+++ b/src/CsToml.Generator/CsToml.Generator.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  
+  <Import Project="../NuGet.props" />
+  
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -12,15 +14,8 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeSymbols>false</IncludeSymbols>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <Authors>prozolic</Authors>
     <Description>Code generator for CsToml.</Description>
-    <Copyright>prozolic</Copyright>
-    <PackageProjectUrl>https://github.com/prozolic/CsToml</PackageProjectUrl>
-    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>TOML,serializer</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <PackageTags>TOML,serializer,source generator</PackageTags>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/CsToml/CsToml.csproj
+++ b/src/CsToml/CsToml.csproj
@@ -1,18 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../NuGet.props" />
+
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Authors>prozolic</Authors>
-    <PackageTags>TOML,serializer,parser,writer,reader</PackageTags>
     <Description>TOML Serializer for .NET.</Description>
-    <Copyright>prozolic</Copyright>
-    <PackageProjectUrl>https://github.com/prozolic/CsToml</PackageProjectUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <VersionPrefix>1.3.3</VersionPrefix>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackageTags>TOML,serializer,parser,writer,reader</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CsToml/CsTomlSerializer.cs
+++ b/src/CsToml/CsTomlSerializer.cs
@@ -64,7 +64,7 @@ public static class CsTomlSerializer
         options ??= DefaultOptions;
 
         var document = new TomlDocument();
-        var reader = new Utf8SequenceReader(tomlText);
+        var reader = new Utf8SequenceReader(tomlText, true);
         document.Deserialize(ref reader, options);
 
         try
@@ -87,7 +87,7 @@ public static class CsTomlSerializer
         options ??= DefaultOptions;
 
         var document = new TomlDocument();
-        var reader = new Utf8SequenceReader(tomlSequence);
+        var reader = new Utf8SequenceReader(tomlSequence, true);
         document.Deserialize(ref reader, options);
 
         try
@@ -150,7 +150,7 @@ public static class CsTomlSerializer
     public static T DeserializeValueType<T>(ReadOnlySpan<byte> tomlText, CsTomlSerializerOptions? options = null)
     {
         options ??= DefaultOptions;
-        var utf8SequenceReader = new Utf8SequenceReader(tomlText);
+        var utf8SequenceReader = new Utf8SequenceReader(tomlText, true);
         var reader = new CsTomlReader(ref utf8SequenceReader);
         TomlValue tomlValue = reader.ReadValue();
 
@@ -161,7 +161,7 @@ public static class CsTomlSerializer
     public static T DeserializeValueType<T>(ReadOnlySequence<byte> tomlSequence, CsTomlSerializerOptions? options = null)
     {
         options ??= DefaultOptions;
-        var utf8SequenceReader = new Utf8SequenceReader(tomlSequence);
+        var utf8SequenceReader = new Utf8SequenceReader(tomlSequence, true);
         var reader = new CsTomlReader(ref utf8SequenceReader);
         TomlValue tomlValue = reader.ReadValue();
 

--- a/src/CsToml/TomlDocument.cs
+++ b/src/CsToml/TomlDocument.cs
@@ -7,28 +7,8 @@ using System.Diagnostics;
 namespace CsToml;
 
 [DebuggerDisplay("Toml Document = {table.RootNode.NodeCount}")]
-public partial class TomlDocument : ITomlSerializedObject<TomlDocument>
+public partial class TomlDocument
 {
-    #region ITomlSerializedObject
-
-    static void ITomlSerializedObject<TomlDocument>.Serialize<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer, TomlDocument? target, CsTomlSerializerOptions options)
-    {
-        // No registration required
-    }
-
-    static TomlDocument ITomlSerializedObject<TomlDocument>.Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
-    {
-        // No registration required
-        return default!;
-    }
-
-    static void ITomlSerializedObjectRegister.Register()
-    {
-        // No registration required
-    }
-
-    #endregion
-
     private readonly TomlTable table;
 
     public TomlDocumentNode RootNode

--- a/src/CsToml/Utf8TomlDocumentWriter.cs
+++ b/src/CsToml/Utf8TomlDocumentWriter.cs
@@ -155,7 +155,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
         {
             if (totalMicrosecond == 0)
             {
-                WriteOffsetDateTimeCore(value, "u");
+                WriteOffsetDateTimeCore(value, "yyyy-MM-ddTHH:mm:ssZ");
             }
             else
             {
@@ -427,12 +427,6 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
         {
             length *= 2;
             buffer = writer.GetSpan(length);
-        }
-
-        // ex 1979-05-27 07:32:00Z -> 1979-05-27T07:32:00Z
-        if (value.Offset == TimeSpan.Zero)
-        {
-            buffer[10] = TomlCodes.Alphabet.T;
         }
 
         writer.Advance(bytesWritten);

--- a/src/CsToml/Values/TomlArray.cs
+++ b/src/CsToml/Values/TomlArray.cs
@@ -101,9 +101,6 @@ internal sealed partial class TomlArray(int capacity) : TomlValue, IEnumerable<T
     }
 
     public override string ToString(string? format, IFormatProvider? formatProvider)
-        => ToString();
-
-    public override string ToString()
     {
         var length = 1024;
         var bufferWriter = RecycleArrayPoolBufferWriter<char>.Rent();
@@ -111,7 +108,7 @@ internal sealed partial class TomlArray(int capacity) : TomlValue, IEnumerable<T
         {
             var conflictCount = 0;
             var charsWritten = 0;
-            while (!TryFormat(bufferWriter.GetSpan(length), out charsWritten))
+            while (!TryFormat(bufferWriter.GetSpan(length), out charsWritten, format.AsSpan(), formatProvider))
             {
                 if (++conflictCount >= 20)
                 {
@@ -128,6 +125,8 @@ internal sealed partial class TomlArray(int capacity) : TomlValue, IEnumerable<T
             RecycleArrayPoolBufferWriter<char>.Return(bufferWriter);
         }
     }
+
+    public override string ToString() => ToString(null, null);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Add(TomlValue tomlValue)

--- a/src/CsToml/Values/TomlBoolean.cs
+++ b/src/CsToml/Values/TomlBoolean.cs
@@ -27,9 +27,6 @@ internal sealed partial class TomlBoolean : TomlValue
         writer.WriteBoolean(Value);
     }
 
-    public override string ToString()
-        => GetString();
-
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
     {
         var destinationSize = Value ? 4 : 5;
@@ -45,11 +42,7 @@ internal sealed partial class TomlBoolean : TomlValue
     }
 
     public override string ToString(string? format, IFormatProvider? formatProvider)
-    {
-        Span<char> destination = Value ? stackalloc char[4] : stackalloc char[5];
-        TryFormat(destination, out var charsWritten, format.AsSpan(), formatProvider);
-        return destination.ToString();
-    }
+        => Value ? bool.TrueString : bool.FalseString;
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
     {
@@ -82,6 +75,9 @@ internal sealed partial class TomlBoolean : TomlValue
         }
         return true;
     }
+
+    public override string ToString()
+        => Value ? bool.TrueString : bool.FalseString;
 
     public static TomlBoolean Parse(ReadOnlySpan<byte> bytes)
     {

--- a/src/CsToml/Values/TomlDottedKey.cs
+++ b/src/CsToml/Values/TomlDottedKey.cs
@@ -132,17 +132,13 @@ internal abstract partial class TomlDottedKey(ReadOnlySpan<byte> value) :
         }
     }
 
-    public override string ToString()
-        => Utf16String;
-
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
     {
         var status = Utf8.ToUtf16(Value, destination, out var bytesRead, out charsWritten, replaceInvalidSequences: false);
         return status == OperationStatus.Done;
     }
 
-    public override string ToString(string? format, IFormatProvider? formatProvider)
-        => GetString();
+    public override string ToString(string? format, IFormatProvider? formatProvider) => Utf16String;
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
     {
@@ -156,6 +152,8 @@ internal abstract partial class TomlDottedKey(ReadOnlySpan<byte> value) :
         bytesWritten = Value.Length;
         return true;
     }
+
+    public override string ToString() => Utf16String;
 
     public override bool Equals(object? obj)
     {

--- a/src/CsToml/Values/TomlFloat.GetValue.cs
+++ b/src/CsToml/Values/TomlFloat.GetValue.cs
@@ -6,12 +6,7 @@ internal partial class TomlFloat
     public override bool CanGetValue(TomlValueFeature feature)
         => ((TomlValueFeature.String | TomlValueFeature.Int64 | TomlValueFeature.Double | TomlValueFeature.Bool | TomlValueFeature.Number | TomlValueFeature.Object) & feature) == feature;
 
-    public override string GetString()
-    {
-        Span<char> destination = stackalloc char[32];
-        TryFormat(destination, out var charsWritten, null, null);
-        return destination[..charsWritten].ToString();
-    }
+    public override string GetString() => ToString();
 
     public override long GetInt64() => (long)Value;
 

--- a/src/CsToml/Values/TomlFloat.cs
+++ b/src/CsToml/Values/TomlFloat.cs
@@ -1,5 +1,6 @@
 ﻿using CsToml.Error;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace CsToml.Values;
 
@@ -52,24 +53,43 @@ internal sealed partial class TomlFloat(double value, TomlFloat.FloatKind kind =
         return;
     }
 
-    public override string ToString()
-        => GetString();
-
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(destination, out charsWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(destination, out charsWritten, format, CultureInfo.InvariantCulture);
+        }
+
+        return Value.TryFormat(destination, out charsWritten, format, provider);
+    }
 
     public override string ToString(string? format, IFormatProvider? formatProvider)
-        => Value.ToString(format, formatProvider);
+    {
+        if (string.IsNullOrEmpty(format) && formatProvider == null)
+        {
+            return ToString();
+        }
+
+        return Value.ToString(format, formatProvider);
+    }
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(utf8Destination, out bytesWritten, format, CultureInfo.InvariantCulture);
+        }
 
+        return Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    }
+
+    public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
 
     public static TomlFloat Parse(ReadOnlySpan<byte> bytes)
     {
         if (bytes.Length < 3) ExceptionHelper.ThrowIncorrectTomlFloatFormat();
 
-        if (double.TryParse(bytes, out var value))
+        if (double.TryParse(bytes, CultureInfo.InvariantCulture, out var value))
         {
             return new TomlFloat(value);
         }

--- a/src/CsToml/Values/TomlInlineTable.GetValue.cs
+++ b/src/CsToml/Values/TomlInlineTable.GetValue.cs
@@ -7,11 +7,9 @@ internal partial class TomlInlineTable
     public override bool CanGetValue(TomlValueFeature feature)
         => ((TomlValueFeature.String | TomlValueFeature.InlineTable | TomlValueFeature.Object) & feature) == feature;
 
-    public override string GetString()
-        => ToString();
+    public override string GetString() => ToString();
 
-    public override object GetObject()
-        => GetDictionary();
+    public override object GetObject() => GetDictionary();
 
 }
 

--- a/src/CsToml/Values/TomlInteger.GetValue.cs
+++ b/src/CsToml/Values/TomlInteger.GetValue.cs
@@ -6,12 +6,7 @@ internal partial class TomlInteger
     public override bool CanGetValue(TomlValueFeature feature)
         => ((TomlValueFeature.String | TomlValueFeature.Int64 | TomlValueFeature.Double | TomlValueFeature.Bool | TomlValueFeature.Number | TomlValueFeature.Object) & feature) == feature;
 
-    public override string GetString()
-    {
-        Span<char> destination = stackalloc char[32];
-        TryFormat(destination, out var charsWritten, null, null);
-        return destination[..charsWritten].ToString();
-    }
+    public override string GetString() => ToString();
 
     public override long GetInt64() => Value;
 

--- a/src/CsToml/Values/TomlInteger.cs
+++ b/src/CsToml/Values/TomlInteger.cs
@@ -1,6 +1,7 @@
 ﻿using CsToml.Error;
 using System.Buffers.Text;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -48,17 +49,34 @@ internal sealed partial class TomlInteger : TomlValue
         writer.WriteInt64(Value);
     }
 
-    public override string ToString()
-        => GetString();
-
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(destination, out charsWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(destination, out charsWritten, format, CultureInfo.InvariantCulture);
+        }
+        return Value.TryFormat(destination, out charsWritten, format, provider);
+    }
 
     public override string ToString(string? format, IFormatProvider? formatProvider)
-        => Value.ToString(format, formatProvider);
+    {
+        if (string.IsNullOrEmpty(format) && formatProvider == null)
+        {
+            return ToString();
+        }
+        return Value.ToString(format, formatProvider);
+    }
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(utf8Destination, out bytesWritten, format, CultureInfo.InvariantCulture);
+        }
+        return Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    }
+
+    public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
 
     public static TomlInteger Parse(ReadOnlySpan<byte> bytes)
     {

--- a/src/CsToml/Values/TomlLocalDate.GetValue.cs
+++ b/src/CsToml/Values/TomlLocalDate.GetValue.cs
@@ -8,12 +8,7 @@ internal partial class TomlLocalDate
     public override bool CanGetValue(TomlValueFeature feature)
         => ((TomlValueFeature.String | TomlValueFeature.DateTime | TomlValueFeature.DateTimeOffset | TomlValueFeature.DateOnly | TomlValueFeature.Object) & feature) == feature;
 
-    public override string GetString()
-    {
-        Span<char> destination = stackalloc char[32];
-        TryFormat(destination, out var charsWritten, null, null);
-        return destination[..charsWritten].ToString();
-    }
+    public override string GetString() => ToString();
 
     public override DateTime GetDateTime() => Value.ToLocalDateTime();
 

--- a/src/CsToml/Values/TomlLocalDate.cs
+++ b/src/CsToml/Values/TomlLocalDate.cs
@@ -1,5 +1,7 @@
 ﻿using CsToml.Error;
+using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace CsToml.Values;
 
@@ -15,17 +17,34 @@ internal sealed partial class TomlLocalDate(DateOnly value) : TomlValue
         writer.WriteDateOnly(Value);
     }
 
-    public override string ToString()
-        => GetString();
-
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(destination, out charsWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(destination, out charsWritten, "yyyy-MM-dd", provider);
+        }
+        return Value.TryFormat(destination, out charsWritten, format, provider);
+    }
 
     public override string ToString(string? format, IFormatProvider? formatProvider)
-        => Value.ToString(format, formatProvider);
+    {
+        if (string.IsNullOrEmpty(format) && formatProvider == null)
+        {
+            return Value.ToString("yyyy-MM-dd");
+        }
+        return Value.ToString(format, formatProvider);
+    }
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(utf8Destination, out bytesWritten, "yyyy-MM-dd", provider);
+        }
+        return Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    }
+
+    public override string ToString() => Value.ToString("yyyy-MM-dd");
 
     public static TomlLocalDate Parse(ReadOnlySpan<byte> bytes)
     {

--- a/src/CsToml/Values/TomlLocalDateTime.GetValue.cs
+++ b/src/CsToml/Values/TomlLocalDateTime.GetValue.cs
@@ -6,12 +6,7 @@ internal partial class TomlLocalDateTime
     public override bool CanGetValue(TomlValueFeature feature)
         => ((TomlValueFeature.String | TomlValueFeature.DateTime | TomlValueFeature.DateTimeOffset | TomlValueFeature.DateOnly | TomlValueFeature.TimeOnly | TomlValueFeature.Object) & feature) == feature;
 
-    public override string GetString()
-    {
-        Span<char> destination = stackalloc char[32];
-        TryFormat(destination, out var charsWritten, null, null);
-        return destination[..charsWritten].ToString();
-    }
+    public override string GetString() => ToString();
 
     public override DateTime GetDateTime() => Value;
 

--- a/src/CsToml/Values/TomlLocalDateTime.cs
+++ b/src/CsToml/Values/TomlLocalDateTime.cs
@@ -15,17 +15,34 @@ internal sealed partial class TomlLocalDateTime(DateTime value) : TomlValue
         writer.WriteDateTime(Value);
     }
 
-    public override string ToString()
-        => GetString();
-
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(destination, out charsWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(destination, out charsWritten, "yyyy-MM-ddTHH:mm:ss.fffffff", provider);
+        }
+        return Value.TryFormat(destination, out charsWritten, format, provider);
+    }
 
     public override string ToString(string? format, IFormatProvider? formatProvider)
-        => Value.ToString(format, formatProvider);
+    {
+        if (string.IsNullOrEmpty(format) && formatProvider == null)
+        {
+            return ToString();
+        }
+        return Value.ToString(format, formatProvider);
+    }
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(utf8Destination, out bytesWritten, "yyyy-MM-ddTHH:mm:ss.fffffff", provider);
+        }
+        return Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    }
+
+    public override string ToString() => Value.ToString("yyyy-MM-ddTHH:mm:ss.fffffff"); // Time zone information ('zzz') is not included.
 
     public static TomlLocalDateTime Parse(ReadOnlySpan<byte> bytes)
     {

--- a/src/CsToml/Values/TomlLocalTime.GetValue.cs
+++ b/src/CsToml/Values/TomlLocalTime.GetValue.cs
@@ -6,12 +6,7 @@ internal partial class TomlLocalTime
     public override bool CanGetValue(TomlValueFeature feature)
         => ((TomlValueFeature.String | TomlValueFeature.TimeOnly | TomlValueFeature.Object) & feature) == feature;
 
-    public override string GetString()
-    {
-        Span<char> destination = stackalloc char[32];
-        TryFormat(destination, out var charsWritten, null, null);
-        return destination[..charsWritten].ToString();
-    }
+    public override string GetString() => ToString();
 
     public override TimeOnly GetTimeOnly() => Value;
 

--- a/src/CsToml/Values/TomlLocalTime.cs
+++ b/src/CsToml/Values/TomlLocalTime.cs
@@ -15,17 +15,34 @@ internal sealed partial class TomlLocalTime(TimeOnly value) : TomlValue
         writer.WriteTimeOnly(Value);
     }
 
-    public override string ToString()
-        => GetString();
-
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(destination, out charsWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(destination, out charsWritten, "HH:mm:ss.fffffff", provider);
+        }
+        return Value.TryFormat(destination, out charsWritten, format, provider);
+    }
 
     public override string ToString(string? format, IFormatProvider? formatProvider)
-        => Value.ToString(format, formatProvider);
+    {
+        if (string.IsNullOrEmpty(format) && formatProvider == null)
+        {
+            return ToString();
+        }
+        return Value.ToString(format, formatProvider);
+    }
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(utf8Destination, out bytesWritten, "HH:mm:ss.fffffff", provider);
+        }
+        return Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    }
+
+    public override string ToString() => Value.ToString("HH:mm:ss.fffffff");
 
     public static TomlLocalTime Parse(ReadOnlySpan<byte> bytes)
     {

--- a/src/CsToml/Values/TomlOffsetDateTime.GetValue.cs
+++ b/src/CsToml/Values/TomlOffsetDateTime.GetValue.cs
@@ -6,12 +6,7 @@ internal partial class TomlOffsetDateTime
     public override bool CanGetValue(TomlValueFeature feature)
         => ((TomlValueFeature.String | TomlValueFeature.DateTime | TomlValueFeature.DateTimeOffset | TomlValueFeature.DateOnly | TomlValueFeature.TimeOnly | TomlValueFeature.Object) & feature) == feature;
 
-    public override string GetString()
-    {
-        Span<char> destination = stackalloc char[32];
-        TryFormat(destination, out var charsWritten, null, null);
-        return destination[..charsWritten].ToString();
-    }
+    public override string GetString() => ToString();
 
     public override DateTime GetDateTime() => Value.DateTime;
 

--- a/src/CsToml/Values/TomlOffsetDateTime.cs
+++ b/src/CsToml/Values/TomlOffsetDateTime.cs
@@ -15,17 +15,34 @@ internal sealed partial class TomlOffsetDateTime(DateTimeOffset value) : TomlVal
         writer.WriteDateTimeOffset(Value);
     }
 
-    public override string ToString()
-        => GetString();
-
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(destination, out charsWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(destination, out charsWritten, "o", provider);
+        }
+        return Value.TryFormat(destination, out charsWritten, format, provider);
+    }
 
     public override string ToString(string? format, IFormatProvider? formatProvider)
-        => Value.ToString(format, formatProvider);
+    {
+        if (string.IsNullOrEmpty(format) && formatProvider == null)
+        {
+            return ToString();
+        }
+        return Value.ToString(format, formatProvider);
+    }
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    {
+        if (format.Length == 0 && provider == null)
+        {
+            return Value.TryFormat(utf8Destination, out bytesWritten, "o", provider);
+        }
+        return Value.TryFormat(utf8Destination, out bytesWritten, format, provider);
+    }
+
+    public override string ToString() => Value.ToString("o");
 
     public static TomlOffsetDateTime Parse(ReadOnlySpan<byte> bytes)
     {

--- a/src/CsToml/Values/TomlString.cs
+++ b/src/CsToml/Values/TomlString.cs
@@ -240,14 +240,15 @@ internal abstract partial class TomlString(string value) : TomlValue, ITomlStrin
         return true;
     }
 
-    public override string ToString(string? format, IFormatProvider? formatProvider)
-        => GetString();
+    public override string ToString(string? format, IFormatProvider? formatProvider) => Utf16String;
 
     public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
     {
         var status = Utf8.FromUtf16(Utf16String.AsSpan(), utf8Destination, out var bytesRead, out bytesWritten, replaceInvalidSequences: false);
         return status == OperationStatus.Done;
     }
+
+    public override string ToString() => Utf16String;
 }
 
 internal enum CsTomlStringType : byte

--- a/src/CsToml/Values/TomlTableNodeDictionary.cs
+++ b/src/CsToml/Values/TomlTableNodeDictionary.cs
@@ -192,7 +192,7 @@ internal class TomlTableNodeDictionary
         public TomlTableNode value;
     }
 
-    internal ref struct KeyValuePairEnumerator
+    internal struct KeyValuePairEnumerator
     {
         private readonly TomlTableNodeDictionary dictionary;
         private int index;

--- a/src/CsToml/Values/TomlValue.cs
+++ b/src/CsToml/Values/TomlValue.cs
@@ -37,9 +37,43 @@ public abstract partial class TomlValue :
         return false;
     }
 
-    [DebuggerDisplay("Empty")]
+    [DebuggerDisplay("{DisplayValue}")]
     private sealed class CsTomlEmpty : TomlValue
     {
+        internal static readonly string DisplayValue = "Empty value";
+
         public CsTomlEmpty() : base() { }
+
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            var displayValueSpan = DisplayValue.AsSpan();
+            if (destination.Length < displayValueSpan.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+            displayValueSpan.CopyTo(destination);
+            charsWritten = displayValueSpan.Length;
+            return true;
+        }
+
+        public override string ToString(string? format, IFormatProvider? formatProvider)
+            => DisplayValue;
+
+        public override bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            var displayValueSpan = "Empty"u8;
+            if (utf8Destination.Length < displayValueSpan.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+            displayValueSpan.CopyTo(utf8Destination);
+            bytesWritten = displayValueSpan.Length;
+            return true;
+        }
+
+        public override string ToString()
+            => DisplayValue;
     }
 }

--- a/src/NuGet.props
+++ b/src/NuGet.props
@@ -1,0 +1,19 @@
+<Project>
+    <PropertyGroup>
+        <VersionPrefix>1.4.0</VersionPrefix>
+        <Authors>prozolic</Authors>
+        <Description>Microsoft.Extensions.Configuration extensions using CsToml.</Description>
+        <Copyright>prozolic</Copyright>
+        <PackageProjectUrl>https://github.com/prozolic/CsToml</PackageProjectUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <VersionPrefix>1.4.0</VersionPrefix>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="../../README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+</Project>

--- a/tests/CsToml.Extensions.Configuration.Tests/ConfigurationTest.cs
+++ b/tests/CsToml.Extensions.Configuration.Tests/ConfigurationTest.cs
@@ -1,5 +1,8 @@
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
 using Shouldly;
+using System;
+using System.Xml.Linq;
 
 namespace CsToml.Extensions.Configuration.Tests;
 
@@ -18,5 +21,70 @@ public class ConfigurationTest
             using var fs = new FileStream("test.toml", FileMode.Open);
             var conf = new ConfigurationBuilder().AddTomlStream(fs).Build();
         });
+    }
+
+    [Fact]
+    public void EqualsTest()
+    {
+        var toml = @"
+key = ""value""
+physical.color = ""orange""
+int1 = +99
+flt2 = 3.1415
+bool1 = true
+odt2 = 1979-05-27T00:32:00-07:00
+ldt2 = 1979-05-27T00:32:00.999999
+ld1 = 1979-05-27
+lt1 = 07:32:00
+integers = [ 1, 2, 3 ]
+
+[Table]
+key1 = ""some string""
+key2 = 123
+
+[fruit]
+apple.color = ""red""
+apple.sweet = true
+
+[[products]]
+name = ""Hammer""
+
+[[products]]  # empty table within the array
+
+[[products]]
+name = ""Tom""
+
+"u8;
+        var ms = new MemoryStream(toml.ToArray());
+        var conf = new ConfigurationBuilder().AddTomlStream(ms).Build();
+
+        var actual = new Test();
+        conf.Bind(actual);
+
+        var expected = new Test()
+        {
+            Key = "value",
+            Physical = new Physical() { Color = "orange" },
+            Int1 = 99,
+            Flt2 = 3.1415,
+            Bool1 = true,
+            Odt2 = new DateTimeOffset(1979, 05, 27, 0, 32, 0, new TimeSpan(-7, 0, 0)),
+            Ldt2 = new DateTime(1979, 05, 27, 0, 32, 0, 999, 999),
+            Ld1 = new DateOnly(1979, 05, 27),
+            Lt1 = new TimeOnly(7, 32, 0),
+            Integers = [1, 2, 3],
+            Table = new Table() { Key1 = "some string", Key2 = 123 },
+            Fruit = new Dictionary<string, Fruit>()
+            {
+                ["apple"] = new Fruit() { Color = "red", Sweet = true }
+            },
+            Products = new List<Product>()
+            {
+                new Product() { Name = "Hammer" },
+                new Product() { Name = "Tom" }
+            },
+        };
+
+        actual.ShouldBeEquivalentTo(expected);
     }
 }

--- a/tests/CsToml.Extensions.Configuration.Tests/ConfigurationTest.cs
+++ b/tests/CsToml.Extensions.Configuration.Tests/ConfigurationTest.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace CsToml.Extensions.Configuration.Tests;
+
+
+public class ConfigurationTest
+{
+    [Fact]
+    public void ConfigurationBuilderTest()
+    {
+        Should.NotThrow(() =>
+        {
+            var conf = new ConfigurationBuilder().AddTomlFile("test.toml").Build();
+        });
+        Should.NotThrow(() =>
+        {
+            using var fs = new FileStream("test.toml", FileMode.Open);
+            var conf = new ConfigurationBuilder().AddTomlStream(fs).Build();
+        });
+    }
+}

--- a/tests/CsToml.Extensions.Configuration.Tests/CsToml.Extensions.Configuration.Tests.csproj
+++ b/tests/CsToml.Extensions.Configuration.Tests/CsToml.Extensions.Configuration.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/CsToml.Extensions.Configuration.Tests/CsToml.Extensions.Configuration.Tests.csproj
+++ b/tests/CsToml.Extensions.Configuration.Tests/CsToml.Extensions.Configuration.Tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="test.toml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CsToml.Extensions.Configuration\CsToml.Extensions.Configuration.csproj" />
+    <ProjectReference Include="..\..\src\CsToml\CsToml.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CsToml.Extensions.Configuration.Tests/TypeDeclarations.cs
+++ b/tests/CsToml.Extensions.Configuration.Tests/TypeDeclarations.cs
@@ -1,0 +1,42 @@
+﻿
+namespace CsToml.Extensions.Configuration.Tests;
+
+public record Test
+{
+    public string? Key { get; init; }
+    public Physical? Physical { get; init; }
+    public int Int1 { get; init; }
+    public double Flt2 { get; init; }
+    public bool Bool1 { get; init; }
+    public DateTimeOffset Odt2 { get; init; }
+    public DateTime Ldt2 { get; init; }
+    public DateOnly Ld1 { get; init; }
+    public TimeOnly Lt1 { get; init; }
+    public int[] Integers { get; init; }
+    public Table? Table { get; init; }
+    public Dictionary<string, Fruit>? Fruit { get; init; }
+    public List<Product>? Products { get; init; }
+
+}
+
+public record Physical
+{
+    public string? Color { get; init; }
+}
+
+public record Fruit
+{
+    public string? Color { get; init; }
+    public bool Sweet { get; init; }
+}
+
+public record Table
+{
+    public string? Key1 { get; init; }
+    public int Key2 { get; init; }
+}
+
+public record Product
+{
+    public string? Name { get; init; }
+}

--- a/tests/CsToml.Extensions.Configuration.Tests/test.toml
+++ b/tests/CsToml.Extensions.Configuration.Tests/test.toml
@@ -1,0 +1,210 @@
+# This is a full-line comment
+
+"Name\tJos\u00E9" = 123
+s = ''''''
+ss = '''''''
+sss = ''''''''
+s2 = '''' '''
+s3 = ''''' '''
+s4 = ''' ''''
+s5 = ''' '''''
+s6 = ''' ' ' '' ' ' '' ' '' ' ''   '     a ' '''
+i = {j = 12, a = 12}
+key = "value"
+bare_key = "value"
+bare-key = "value"
+1234 = "value"
+"127.0.0.1" = "value"
+"character encoding" = "value"
+"ʎǝʞ" = "value"
+'key2' = "value"
+'quoted "value"' = "value"
+'' = 'blank'     # VALID but discouraged
+name = "Orange"
+physical.color = "orange"
+physical2.color.color = "orange2"
+physical.shape = "round"
+site."google.com" = true
+
+str = "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF."
+str1 = "The quick brown fox jumps over the lazy dog."
+
+str2 = """
+The quick brown \
+
+
+  fox jumps over \
+    the lazy dog."""
+
+str3 = """\
+       The quick brown \
+       fox jumps over \
+       the lazy dog.\
+       """
+
+str4 = """Here are two quotation marks: "". Simple enough."""
+# str5 = """Here are three quotation marks: """."""  # INVALID
+str5 = """Here are three quotation marks: ""\"."""
+str6 = """Here are fifteen quotation marks: ""\"""\"""\"""\"""\"."""
+
+# "This," she said, "is just a pointless statement."
+str7 = """"This," she said, "is just a pointless statement.""""
+str8 = """Here are fifteen quotation marks: ""\"""\"""\"""\"""\"."""
+str9 = """"""""
+str10 = """""""
+str11 = """"""
+str12 = """ """""
+str13 = """"" """
+str14 = """"" """""
+
+# What you see is what you get.
+winpath  = 'C:\Users\nodejs\templates'
+winpath2 = '\\ServerX\admin$\system32\'
+quoted   = 'Tom "Dubs" Preston-Werner'
+regex    = '<\i\c*\s*>'
+regex2 = '''I [dw]on't need \d{2} apples'''
+lines  = '''
+The first newline is
+trimmed in raw strings.
+   All other whitespace
+   is preserved.
+'''
+
+# int
+
+int1 = +99
+int2 = 42
+int3 = 0
+int4 = -17
+int5 = 1_000
+int6 = 5_349_221
+int7 = 53_49_221  # Indian number system grouping
+int8 = 1_2_3_4_5  # VALID but discouraged
+
+# hexadecimal with prefix `0x`
+hex1 = 0xDEADBEEF
+hex2 = 0xdeadbeef
+hex3 = 0xdead_beef
+
+# octal with prefix `0o`
+oct1 = 0o01234567
+oct2 = 0o755 # useful for Unix file permissions
+
+# binary with prefix `0b`
+bin1 = 0b11010110
+
+# fractional
+flt1 = +1.0
+flt2 = 3.1415
+flt3 = -0.01
+
+# exponent
+flt4 = 5e+22
+flt5 = 1e06
+flt6 = -2E-2
+
+flt7 = 6.626e-34
+flt8 = 9_224_617.445_991_228_313
+
+# infinity
+sf1 = inf  # positive infinity
+sf2 = +inf # positive infinity
+sf3 = -inf # negative infinity
+
+# not a number
+sf4 = nan  # actual sNaN/qNaN encoding is implementation-specific
+sf5 = +nan # same as `nan`
+sf6 = -nan # valid, actual encoding is implementation-specific
+
+# bool
+bool1 = true
+bool2 = false
+
+# date
+odt1 = 1979-05-27T07:32:00Z
+odt2 = 1979-05-27T00:32:00-07:00
+odt3 = 1979-05-27T00:32:00.999999-07:00
+odt4 = 1979-05-27T07:32:00Z
+odt5 = 1979-05-27 07:32:00Z
+odt6 = 1979-05-27 00:32:00-07:00
+odt7 = 1979-05-27 00:32:00.999999-07:00
+odt8 = 1979-05-27 07:32:00Z
+ldt1 = 1979-05-27T07:32:00
+ldt2 = 1979-05-27T00:32:00.999999
+ldt3 = 1979-05-27 07:32:00
+ldt4 = 1979-05-27 00:32:00.999999
+ld1 = 1979-05-27
+lt1 = 07:32:00
+lt2 = 00:32:00.999999
+
+# array
+integers = [ 1, 2, 3 ]
+colors = [ "red", "yellow", "green" ]
+nested_array_of_int = [ [ 1, 2 ], [3, 4, 5] ]
+nested_mixed_array = [ [ 1, 2 ], ["a", "b", "c"] ]
+string_array = [ "all", 'strings', """are the same""", '''type''' ]
+
+# Mixed-type arrays are allowed
+numbers = [ 0.1, 0.2, 0.5, 1, 2, 5 ]
+contributors = [
+  "Foo Bar <foo@example.com>",
+  { name = "Baz Qux", email = "bazqux@example.com", url = "https://example.com/bazqux" }
+]
+integers2 = [
+  1, 2, 3
+]
+
+integers3 = [
+  1,
+  2, # this is ok
+]
+
+[Dict]
+key.a.b.v = "value"
+#ab = [1, {key = [1, [1, {test = 123, TEST2 = [67,90]} ] , 5], key2 = {key3 = 0.1, key4 = 123}}, 23]
+
+# table
+[table-1]
+key1 = "some string"
+key2 = 123
+
+[table-2]
+key1 = "another string"
+key2 = 456
+
+[dog."tater.man"]
+type.name = "pug"
+
+[fruit]
+apple.color = "red"
+apple.taste.sweet = true
+
+
+[fruit.apple.texture]  # you can add sub-tables
+smooth = true
+
+name = { first = "Tom", last = "Preston-Werner" }
+point = { x = 1, y = 2 }
+animal = { type.name = "pug" }
+
+
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]  # empty table within the array
+
+[[products]]
+name = "Nail"
+sku = 284758393
+
+color = "gray"
+
+[[array.of.tables]]
+
+[[array.of.tables]]
+test = 2
+arr = [2, "tes2", 8]
+
+[[array.of.tables]]
+name = { type.name.x.y = { first.name = "Tom", last.name = "Preston-Werner" }, last = "Preston-Werner", array = [0,  { x = 1, y = 2, z = [999] }], last2 = { key = "Preston-Werner"}}

--- a/tests/CsToml.Tests/GetValueTest.cs
+++ b/tests/CsToml.Tests/GetValueTest.cs
@@ -348,7 +348,7 @@ value3 = 3
     public void OffsetDateTimeTest()
     {
         var value = document.RootNode["odt"u8];
-        value!.GetString().ShouldBe(new DateTimeOffset(1979, 5, 27, 7, 32, 0, TimeSpan.Zero).ToString());
+        value!.GetString().ShouldBe(new DateTimeOffset(1979, 5, 27, 7, 32, 0, TimeSpan.Zero).ToString("o"));
         Assert.Throws<CsTomlException>(() => value!.GetInt64());
         Assert.Throws<CsTomlException>(() => value!.GetDouble());
         Assert.Throws<CsTomlException>(() => value!.GetBool());
@@ -369,7 +369,7 @@ value3 = 3
         var value = document.RootNode["odt"u8];
         {
             value!.TryGetString(out var v).ShouldBeTrue();
-            v.ShouldBe(new DateTimeOffset(1979, 5, 27, 7, 32, 0, TimeSpan.Zero).ToString());
+            v.ShouldBe(new DateTimeOffset(1979, 5, 27, 7, 32, 0, TimeSpan.Zero).ToString("o"));
         }
         var utcTime1 = DateTime.SpecifyKind(new DateTime(1979, 5, 27, 7, 32, 0), DateTimeKind.Utc);
         DateTimeOffset utcTime2 = utcTime1;
@@ -400,7 +400,7 @@ value3 = 3
     public void LocalDateTimeTest()
     {
         var value = document.RootNode["ldt"u8];
-        value.GetString()!.ShouldBe(new DateTime(1979, 5, 27, 7, 32, 0).ToString());
+        value.GetString()!.ShouldBe(new DateTime(1979, 5, 27, 7, 32, 0).ToString("yyyy-MM-ddTHH:mm:ss.fffffff"));
         Assert.Throws<CsTomlException>(() => value!.GetInt64());
         Assert.Throws<CsTomlException>(() => value!.GetDouble());
         Assert.Throws<CsTomlException>(() => value!.GetBool());
@@ -420,7 +420,7 @@ value3 = 3
         var value = document.RootNode["ldt"u8];
         {
             value!.TryGetString(out var v).ShouldBeTrue();
-            v.ShouldBe(new DateTime(1979, 5, 27, 7, 32, 0).ToString());
+            v.ShouldBe(new DateTime(1979, 5, 27, 7, 32, 0).ToString("yyyy-MM-ddTHH:mm:ss.fffffff"));
         }
 
         var utcTime1 = new DateTime(1979, 5, 27, 7, 32, 0);
@@ -452,7 +452,7 @@ value3 = 3
     public void LocalDateTest()
     {
         var value = document.RootNode["ld1"u8];
-        value!.GetString()!.ShouldBe(new DateOnly(1979, 5, 27).ToString());
+        value!.GetString()!.ShouldBe(new DateOnly(1979, 5, 27).ToString("yyyy-MM-dd"));
         Assert.Throws<CsTomlException>(() => value!.GetInt64());
         Assert.Throws<CsTomlException>(() => value!.GetDouble());
         Assert.Throws<CsTomlException>(() => value!.GetBool());
@@ -472,7 +472,7 @@ value3 = 3
         var value = document.RootNode["ld1"u8];
         {
             value!.TryGetString(out var v).ShouldBeTrue();
-            v.ShouldBe(new DateOnly(1979, 5, 27).ToString());
+            v.ShouldBe(new DateOnly(1979, 5, 27).ToString("yyyy-MM-dd"));
         }
         var utcTime1 = new DateTime(1979, 5, 27);
         DateTimeOffset utcTime2 = utcTime1;
@@ -500,7 +500,7 @@ value3 = 3
     public void LocalTimeTest()
     {
         var value = document.RootNode["lt1"u8];
-        value!.GetString()!.ShouldBe(new TimeOnly(7, 32, 30).ToString());
+        value!.GetString()!.ShouldBe(new TimeOnly(7, 32, 30).ToString("HH:mm:ss.fffffff"));
         Assert.Throws<CsTomlException>(() => value!.GetInt64());
         Assert.Throws<CsTomlException>(() => value!.GetDouble());
         Assert.Throws<CsTomlException>(() => value!.GetBool());
@@ -518,7 +518,7 @@ value3 = 3
         var value = document.RootNode["lt1"u8];
         {
             value!.TryGetString(out var v).ShouldBeTrue();
-            v.ShouldBe(new TimeOnly(7, 32, 30).ToString());
+            v.ShouldBe(new TimeOnly(7, 32, 30).ToString("HH:mm:ss.fffffff"));
         }
         {
             value!.TryGetTimeOnly(out var v).ShouldBeTrue();


### PR DESCRIPTION
This PR creates a TOML configuration provider implementation of 'Microsoft.Extensions.Configuration' using CsToml. Also, the culture specification and format of `TomlValue.GetString`(`ToString`) was ambiguous, so it'll fix.

## Related issues
#19
