### PR TITLE
Improved handling of exceptions in CsTomlSerializeException.

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ var dict2 = CsTomlSerializer.Deserialize<Dictionary<object, object>>(tomlText);
 ```
 
 If a syntax error is found during deserialization, an `CsTomlSerializeException` is thrown after deserialization.
-The contents of the thrown exception can be viewed at `CsTomlException.InnerException`.
+The contents of the thrown exception can be viewed at `CsTomlException.ParseExceptions`.
 
 ```csharp
 var tomlText = @"
@@ -526,15 +526,16 @@ number = ""Error
 
 try
 {
-    // throw CsTomlException
+    // throw CsTomlSerializeException
     var error = CsTomlSerializer.Deserialize<TomlDocument>(tomlText);
 }
-catch(CsTomlSerializeException ctse)
+catch (CsTomlSerializeException ctse)
 {
-    foreach (var cte in ctse.Exceptions)
+    foreach (var cte in ctse.ParseExceptions!)
     {
-        // A syntax error (CsTomlException) occurred while parsing line 3 of the TOML file. Check InnerException for details.
-        var e = cte.InnerException; // InnerException: 10 is a character that cannot be converted to a number.
+        // A syntax error (CsTomlException) was thrown during the parsing line 3.
+        var e = cte.InnerException;         // CsToml.Error.CsTomlException: Escape characters 13 were included.
+        var lineNumber = cte.LineNumber;
     }
 }
 ```

--- a/sandbox/ConsoleApp/Program.cs
+++ b/sandbox/ConsoleApp/Program.cs
@@ -246,7 +246,7 @@ try
 }
 catch(CsTomlSerializeException ctse)
 {
-    foreach (var cte in ctse.Exceptions)
+    foreach (var cte in ctse.ParseExceptions!)
     {
         // A syntax error (CsTomlException) occurred while parsing line 3 of the TOML file. Check InnerException for details.
         var e = cte.InnerException;

--- a/src/CsToml/CsTomlParser.cs
+++ b/src/CsToml/CsTomlParser.cs
@@ -51,7 +51,7 @@ internal ref struct CsTomlParser
     private TomlValue? comment;
     private ExtendableArray<TomlDottedKey> dottedKeys;
     private TomlValue? value;
-    private CsTomlLineNumberException? exception;
+    private CsTomlParseException? exception;
     private bool endComment;
 
     public readonly long LineNumber => reader.LineNumber;
@@ -79,7 +79,7 @@ internal ref struct CsTomlParser
 
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly CsTomlLineNumberException? GetException()
+    public readonly CsTomlParseException? GetException()
         => exception;
 
     [DebuggerStepThrough]
@@ -173,7 +173,7 @@ internal ref struct CsTomlParser
         catch (CsTomlException ce)
         {
             CurrentState = ParserState.ThrowException;
-            exception = new CsTomlLineNumberException(ce, LineNumber);
+            exception = new CsTomlParseException(ce, LineNumber);
             // Skip lines where an error is thrown.
             reader.SkipOneLine();
         }

--- a/src/CsToml/CsTomlReader.cs
+++ b/src/CsToml/CsTomlReader.cs
@@ -315,7 +315,7 @@ internal ref struct CsTomlReader
                 return ReadInlineTable();
         }
 
-        ExceptionHelper.NotReturnThrow<TomlValue>(ExceptionHelper.ThrowIncorrectTomlFormat);
+        ExceptionHelper.ThrowUnexpectedValueFound();
         return default!;
     }
 
@@ -1007,6 +1007,7 @@ internal ref struct CsTomlReader
 
         var array = new TomlArray();
         var comma = true;
+        var commaCount = 0;
         var closingBracket = false;
         while (TryPeek(out var ch))
         {
@@ -1021,8 +1022,15 @@ internal ref struct CsTomlReader
                     SkipWhiteSpace();
                     break;
                 case TomlCodes.Symbol.COMMA:
-                    if (comma) ExceptionHelper.ThrowIncorrectTomlFormat();
+                    if (comma)
+                    {
+                        if (commaCount > 0)
+                            ExceptionHelper.ThrowCommasAreUsedMoreThanOnce();
+                        else
+                            ExceptionHelper.ThrowTheCommaIsDefinedFirst();
+                    }
                     comma = true;
+                    commaCount++;
                     Advance(1);
                     break;
                 case TomlCodes.Symbol.CARRIAGE:

--- a/src/CsToml/CsTomlSerializer.cs
+++ b/src/CsToml/CsTomlSerializer.cs
@@ -32,14 +32,7 @@ public static class CsTomlSerializer
 
         public void Serialize<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer, TomlDocument target, CsTomlSerializerOptions options) where TBufferWriter : IBufferWriter<byte>
         {
-            try
-            {
-                target!.ToTomlString(ref writer);
-            }
-            catch (CsTomlException cte)
-            {
-                throw new CsTomlSerializeException("An error occurred when serializing the TOML file. Check InnerException for exception information.", cte);
-            }
+            target!.ToTomlString(ref writer);
         }
 
         public void Dispose()
@@ -78,7 +71,7 @@ public static class CsTomlSerializer
         }
         catch (CsTomlException cte)
         {
-            throw new CsTomlSerializeException("An error occurred when serializing the TOML file. Check InnerException for exception information.", cte);
+            throw new CsTomlSerializeException("An exception was thrown during the deserializing TOML. Check 'InnerException' property for exception information.", cte);
         }
     }
 
@@ -101,7 +94,7 @@ public static class CsTomlSerializer
         }
         catch (CsTomlException cte)
         {
-            throw new CsTomlSerializeException("An error occurred when serializing the TOML file. Check InnerException for exception information.", cte);
+            throw new CsTomlSerializeException("An exception was thrown during the deserializing TOML. Check 'InnerException' property for exception information.", cte);
         }
     }
 
@@ -198,7 +191,7 @@ public static class CsTomlSerializer
         }
         catch (CsTomlException cte)
         {
-            throw new CsTomlSerializeException("An error occurred when serializing the TOML file. Check InnerException for exception information.", cte);
+            throw new CsTomlSerializeException("An exception was thrown during the serializing TOML. Check 'InnerException' property for exception information.", cte);
         }
     }
 
@@ -253,7 +246,7 @@ public static class CsTomlSerializer
         }
         catch (CsTomlException cte)
         {
-            throw new CsTomlSerializeException("An error occurred when serializing the TOML file. Check InnerException for exception information.", cte);
+            throw new CsTomlSerializeException("An exception was thrown during the serializing TOML. Check 'InnerException' property for exception information.", cte);
         }
     }
 }

--- a/src/CsToml/Error/CsTomlException.cs
+++ b/src/CsToml/Error/CsTomlException.cs
@@ -12,22 +12,22 @@ public class CsTomlException : Exception
     {}
 }
 
-public sealed class CsTomlLineNumberException : CsTomlException
+public sealed class CsTomlParseException : CsTomlException
 {
     public long LineNumber { get; } = 0;
 
-    internal CsTomlLineNumberException(string? message, long lineNumber) : base(message)
+    internal CsTomlParseException(string? message, long lineNumber) : base(message)
     {
         LineNumber = lineNumber;
     }
 
-    internal CsTomlLineNumberException(CsTomlException exception, long lineNumber)
+    internal CsTomlParseException(CsTomlException exception, long lineNumber)
         : base(CreateCsTomlExceptionMessage(exception, lineNumber), exception)
     {
         LineNumber = lineNumber;
     }
 
-    internal CsTomlLineNumberException(Exception exception, long lineNumber)
+    internal CsTomlParseException(Exception exception, long lineNumber)
         : base(CreateExceptionMessage(exception, lineNumber), exception)
     {
         LineNumber = lineNumber;
@@ -62,18 +62,18 @@ public sealed class CsTomlLineNumberException : CsTomlException
 
 public sealed class CsTomlSerializeException : CsTomlException
 {
-    public IReadOnlyCollection<CsTomlLineNumberException>? Exceptions { get; }
+    public IReadOnlyCollection<CsTomlParseException>? ParseExceptions { get; }
 
-    internal CsTomlSerializeException(string message, IReadOnlyCollection<CsTomlLineNumberException> exceptions) :
+    internal CsTomlSerializeException(string message, IReadOnlyCollection<CsTomlParseException> parseExceptions) :
         base(message)
     {
-        Exceptions = exceptions;
+        ParseExceptions = parseExceptions;
     }
 
     internal CsTomlSerializeException(string message, CsTomlException e) :
         base(message, e)
     {
-        Exceptions = [];
+        ParseExceptions = [];
     }
 
 }

--- a/src/CsToml/Error/CsTomlException.cs
+++ b/src/CsToml/Error/CsTomlException.cs
@@ -38,29 +38,33 @@ public sealed class CsTomlLineNumberException : CsTomlException
         var handler = new DefaultInterpolatedStringHandler(0, 0);
         handler.AppendLiteral("A syntax error (");
         handler.AppendLiteral(nameof(CsTomlException));
-        handler.AppendLiteral(") occurred while parsing line ");
+        handler.AppendLiteral(") was thrown during the parsing line ");
         handler.AppendFormatted(lineNumber);
-        handler.AppendLiteral(" of the TOML file. Check InnerException for details.");
+        handler.AppendLiteral($".");
+        handler.AppendLiteral(Environment.NewLine);
+        handler.AppendFormatted(e);
         return handler.ToStringAndClear();
     }
 
     internal static string CreateExceptionMessage(Exception e, long lineNumber)
     {
         var handler = new DefaultInterpolatedStringHandler(0, 0);
-        handler.AppendLiteral("An unexpected error (");
+        handler.AppendLiteral("An unexpected exception (");
         handler.AppendLiteral(e.GetType().Name);
-        handler.AppendLiteral(") occurred while parsing line ");
+        handler.AppendLiteral(") was thrown during the parsing line ");
         handler.AppendFormatted(lineNumber);
-        handler.AppendLiteral(" of the TOML file. Check InnerException for details.");
+        handler.AppendLiteral($".");
+        handler.AppendLiteral(Environment.NewLine);
+        handler.AppendFormatted(e);
         return handler.ToStringAndClear();
     }
 }
 
 public sealed class CsTomlSerializeException : CsTomlException
 {
-    public IReadOnlyCollection<CsTomlException>? Exceptions { get; }
+    public IReadOnlyCollection<CsTomlLineNumberException>? Exceptions { get; }
 
-    internal CsTomlSerializeException(string message, IReadOnlyCollection<CsTomlException> exceptions) :
+    internal CsTomlSerializeException(string message, IReadOnlyCollection<CsTomlLineNumberException> exceptions) :
         base(message)
     {
         Exceptions = exceptions;
@@ -69,7 +73,7 @@ public sealed class CsTomlSerializeException : CsTomlException
     internal CsTomlSerializeException(string message, CsTomlException e) :
         base(message, e)
     {
-        Exceptions = [e];
+        Exceptions = [];
     }
 
 }

--- a/src/CsToml/Error/ExceptionHelper.cs
+++ b/src/CsToml/Error/ExceptionHelper.cs
@@ -146,6 +146,13 @@ internal static class ExceptionHelper
 
     [DoesNotReturn]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowUnexpectedValueFound()
+    {
+        ThrowException($@"Unexpected value found.");
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void ThrowIncorrectTomlFormat()
     {
         ThrowException($@"Failed due to incorrect formatting.");
@@ -325,6 +332,20 @@ internal static class ExceptionHelper
     internal static void ThrowUnderscoreUsedConsecutively()
     {
         ThrowException($@"Underscores are used consecutively.");
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowCommasAreUsedMoreThanOnce()
+    {
+        ThrowException($@"Commas are used more than once.");
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowTheCommaIsDefinedFirst()
+    {
+        ThrowException($@"The comma is defined first.");
     }
 
     [DoesNotReturn]

--- a/src/CsToml/Error/ExceptionHelper.cs
+++ b/src/CsToml/Error/ExceptionHelper.cs
@@ -542,7 +542,7 @@ internal static class ExceptionHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void ThrowArgumentOutOfRangeExceptionWhenCreating<T>(ArgumentOutOfRangeException innerException)
     {
-        ThrowException($"ArgumentOutOfRangeException occurred when creating {typeof(T)}.", innerException);
+        ThrowException($"ArgumentOutOfRangeException was thrown when creating {typeof(T)}.", innerException);
     }
 
     [DoesNotReturn]

--- a/src/CsToml/TomlDocument.cs
+++ b/src/CsToml/TomlDocument.cs
@@ -37,7 +37,7 @@ public partial class TomlDocument
         var parser = new CsTomlParser(ref reader);
 
         List<TomlString>? comments = default;
-        List<CsTomlLineNumberException>? exceptions = default;
+        List<CsTomlParseException>? exceptions = default;
         TomlTableNode? currentNode = table.RootNode;
 
         try
@@ -69,7 +69,7 @@ public partial class TomlDocument
                             break;
 
                         case ParserState.ThrowException:
-                            exceptions ??= new List<CsTomlLineNumberException>();
+                            exceptions ??= new List<CsTomlParseException>();
                             exceptions?.Add(parser.GetException()!);
                             comments?.Clear();
                             break;
@@ -80,8 +80,8 @@ public partial class TomlDocument
                 }
                 catch (CsTomlException cte)
                 {
-                    exceptions ??= new List<CsTomlLineNumberException>();
-                    exceptions?.Add(new CsTomlLineNumberException(cte, parser.LineNumber));
+                    exceptions ??= new List<CsTomlParseException>();
+                    exceptions?.Add(new CsTomlParseException(cte, parser.LineNumber));
                 }
             }
 

--- a/src/CsToml/TomlDocument.cs
+++ b/src/CsToml/TomlDocument.cs
@@ -37,7 +37,7 @@ public partial class TomlDocument
         var parser = new CsTomlParser(ref reader);
 
         List<TomlString>? comments = default;
-        List<CsTomlException>? exceptions = default;
+        List<CsTomlLineNumberException>? exceptions = default;
         TomlTableNode? currentNode = table.RootNode;
 
         try
@@ -69,7 +69,7 @@ public partial class TomlDocument
                             break;
 
                         case ParserState.ThrowException:
-                            exceptions ??= new List<CsTomlException>();
+                            exceptions ??= new List<CsTomlLineNumberException>();
                             exceptions?.Add(parser.GetException()!);
                             comments?.Clear();
                             break;
@@ -80,7 +80,7 @@ public partial class TomlDocument
                 }
                 catch (CsTomlException cte)
                 {
-                    exceptions ??= new List<CsTomlException>();
+                    exceptions ??= new List<CsTomlLineNumberException>();
                     exceptions?.Add(new CsTomlLineNumberException(cte, parser.LineNumber));
                 }
             }
@@ -95,7 +95,7 @@ public partial class TomlDocument
         if (exceptions?.Count > 0)
         {
             throw new CsTomlSerializeException(
-                "An error occurred while parsing the TOML file. Check Exceptions for information on exceptions raised during parsing.",
+                "Exceptions were thrown during the parsing TOML. Check 'Exceptions' property about exceptions thrown.",
                 exceptions);
         }
     }

--- a/tests/CsToml.Tests/DefaultTest.cs
+++ b/tests/CsToml.Tests/DefaultTest.cs
@@ -187,7 +187,7 @@ flt = 3.1415
             }
             catch (CsTomlSerializeException ctse)
             {
-                ctse.Exceptions!.Count.ShouldBe(1);
+                ctse.ParseExceptions!.Count.ShouldBe(1);
                 throw;
             }
         });


### PR DESCRIPTION
This PR fix some error messages and It delete `CsTomlSerializeException.Exceptions` and add in its place to `CsTomlSerializeException.ParseExceptions`.
This allows you to get the number of rows (`CsTomlParseException.LineNumber`) without casting when thrown with a syntax error.

```csharp
try
{
    var testCsTomldocument = CsTomlSerializer.Deserialize<TomlDocument>(tomlText);
}
catch(CsTomlSerializeException ctse)
{
    foreach (var cte in ctse.ParseExceptions!)
    {
        // Get the number of lines where a syntax error occurred.
        var lineNumber = cte.LineNumber;
        var e = cte.InnerException;
    }
}
```