### PR TITLE
Fix Native AOT compatible of Deserialize/Serialize

### DIFF
--- a/CsToml.sln
+++ b/CsToml.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsToml.Extensions.Configura
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsToml.Extensions.Configuration.Tests", "tests\CsToml.Extensions.Configuration.Tests\CsToml.Extensions.Configuration.Tests.csproj", "{F7D81327-0320-455D-B1EB-D64E3901752E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleNativeAOT", "sandbox\ConsoleNativeAOT\ConsoleNativeAOT.csproj", "{F3A54690-2C84-4F3F-AEB4-28C4618D61C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{F7D81327-0320-455D-B1EB-D64E3901752E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7D81327-0320-455D-B1EB-D64E3901752E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7D81327-0320-455D-B1EB-D64E3901752E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3A54690-2C84-4F3F-AEB4-28C4618D61C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3A54690-2C84-4F3F-AEB4-28C4618D61C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3A54690-2C84-4F3F-AEB4-28C4618D61C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3A54690-2C84-4F3F-AEB4-28C4618D61C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +89,7 @@ Global
 		{CCCC9670-6422-4583-BDC5-74D475D858A0} = {A9C74E56-F4CF-45C0-8DD4-AEF20E74E454}
 		{57977698-C9B4-4525-85CF-4ADE3859C920} = {A9C74E56-F4CF-45C0-8DD4-AEF20E74E454}
 		{F7D81327-0320-455D-B1EB-D64E3901752E} = {D1DA58D2-DF19-442A-B61A-BE8A473DE878}
+		{F3A54690-2C84-4F3F-AEB4-28C4618D61C2} = {A15E98B9-5239-4EFB-A5D7-6E888B644890}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D2BE6D04-CA64-4762-A4A8-413B4115D763}

--- a/sandbox/ConsoleNativeAOT/ConsoleNativeAOT.csproj
+++ b/sandbox/ConsoleNativeAOT/ConsoleNativeAOT.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <IsAotCompatible>true</IsAotCompatible>
+
+    <!-- AOT Options -->
+    <!-- https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/ -->
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+    <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+    <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CsToml\CsToml.csproj" />
+    <ProjectReference Include="..\..\src\CsToml.Generator\CsToml.Generator.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/sandbox/ConsoleNativeAOT/Program.cs
+++ b/sandbox/ConsoleNativeAOT/Program.cs
@@ -1,0 +1,152 @@
+﻿using CsToml;
+using System.Text;
+
+Console.WriteLine("Hello, World!");
+
+var tomlText = @"
+str = ""value""
+int = 123
+flt = 3.1415
+boolean = true
+odt1 = 1979-05-27T07:32:00Z
+ldt1 = 1979-05-27T07:32:00
+ldt2 = 1979-05-27T00:32:00.999999
+ld1 = 1979-05-27
+lt1 = 07:32:00
+
+key = ""value""
+first.second.third = ""value""
+number = 123456
+intArray = [1, 2, 3, 4, 5]
+Pair =  [1, ""value""]
+inlineTable = { key = 1 , key2 = ""value"" , key3 = [ 123, 456, 789], key4 = { key = ""inlinetable"" }}
+Dict = {key = 1, key2 = 2, key3 = 3, key4 = 4, key5 = 5}
+Dict2 = {key = 10, key2 = 20, key3 = 30, key4 = 40, key5 = 50}
+Dict3 = {123 = ""Value"", -1 = ""Value"", 123456789 = ""Value""}
+TwoValueTuple = [ 1, 2 ]
+TestStructArr = [{Value = 999, Str = ""Test""}, {Value = 9999, Str = ""Test2""}]
+
+[Table.test]
+key = ""value""
+first.second.third = ""value""
+number = 123456
+
+[[arrayOfTables.test]]
+key = ""value""
+first.second.third = ""value""
+number = 123456
+
+[[arrayOfTables.test]]
+
+[[arrayOfTables.test]]
+key2 = ""value""
+first2.second2.third2 = ""value""
+number2 = 123456
+
+"u8;
+
+Console.WriteLine("CsTomlSerializer.Deserialize<TomlDocument>");
+var res = CsTomlSerializer.Deserialize<TomlDocument>(tomlText);
+var rootNode = res.RootNode;
+Console.WriteLine(rootNode["str"u8].GetString());
+Console.WriteLine(rootNode["int"u8].GetInt64());
+Console.WriteLine(rootNode["flt"u8].GetDouble());
+Console.WriteLine(rootNode["boolean"u8].GetBool());
+Console.WriteLine("CsTomlSerializer.Deserialize<TomlDocument> END");
+
+Console.WriteLine("CsTomlSerializer.Deserialize<TestClass>");
+var value = CsTomlSerializer.Deserialize<TestClass>(tomlText);
+Console.WriteLine(value.str);
+Console.WriteLine(value.IntValue);
+Console.WriteLine(value.flt);
+Console.WriteLine(value.boolean);
+Console.WriteLine(value.Pair);
+Console.WriteLine(value.Dict);
+Console.WriteLine(value.Dict2);
+Console.WriteLine(value.Dict3);
+Console.WriteLine(value.TwoValueTuple);
+Console.WriteLine("CsTomlSerializer.Deserialize<TestClass> END");
+
+Console.WriteLine("CsTomlSerializer.Serialize<TestClass>");
+var testClass = new TestClass()
+{
+    str = "value",
+    IntValue = 123,
+    flt = 3.1415f,
+    boolean = true,
+    Dict = new Dictionary<string, object?>()
+    {
+        ["key"] = 2,
+        ["key2"] = 3,
+        ["key3"] = 4,
+        ["key4"] = 5,
+    },
+    Dict2 = new Dictionary<string, object?>()
+    {
+        ["key"] = 2,
+        ["key2"] = 3,
+        ["key3"] = 4,
+        ["key4"] = 5,
+    },
+    Dict3 = new Dictionary<long, string>()
+    {
+        [123] = "Value",
+        [-1] = "Value",
+        [123456789] = "Value",
+    },
+    Pair = new KeyValuePair<int, StringBuilder>(1, new StringBuilder("value")),
+    TwoValueTuple = (1, 2),
+    TestStructArr = new List<TestStruct?>()
+    {
+        new TestStruct() { Value = 999, Str = "Test" },
+        new TestStruct() { Value = 9999, Str = "Test2" },
+    },
+};
+
+using var text = CsTomlSerializer.Serialize(testClass);
+Console.WriteLine(text.ToString());
+Console.WriteLine("CsTomlSerializer.Serialize<TestClass> END");
+
+Console.WriteLine("END!");
+
+[TomlSerializedObject]
+public partial class TestClass
+{
+    [TomlValueOnSerialized] 
+    public string str { get; set; }
+
+    [TomlValueOnSerialized("int")] 
+    public long IntValue { get; set; }
+    [TomlValueOnSerialized]
+    public float flt { get; set; }
+    [TomlValueOnSerialized]
+    public bool boolean { get; set; }
+
+    [TomlValueOnSerialized()]
+    public Dictionary<string, object?> Dict { get; set; }
+
+    [TomlValueOnSerialized()]
+    public IReadOnlyDictionary<string, object?> Dict2 { get; set; }
+
+    [TomlValueOnSerialized()]
+    public Dictionary<long, string> Dict3 { get; set; }
+
+    [TomlValueOnSerialized]
+    public KeyValuePair<int, StringBuilder> Pair { get; set; }
+
+    [TomlValueOnSerialized]
+    public ValueTuple<int, int> TwoValueTuple { get; set; } = default!;
+
+    [TomlValueOnSerialized]
+    public List<TestStruct?> TestStructArr { get; set; }
+}
+
+[TomlSerializedObject]
+public partial struct TestStruct
+{
+    [TomlValueOnSerialized]
+    public int Value { get; set; }
+
+    [TomlValueOnSerialized]
+    public string Str { get; set; }
+}

--- a/src/CsToml.Generator/FormatterTypeMetaData.cs
+++ b/src/CsToml.Generator/FormatterTypeMetaData.cs
@@ -1,0 +1,86 @@
+﻿
+namespace CsToml.Generator;
+
+internal static class FormatterTypeMetaData
+{
+    private static readonly Dictionary<string, string> builtInGeneratedFormatterTypes = new()
+    {
+        { "global::System.Collections.Generic.List<>", "ListFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.Stack<>", "StackFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.HashSet<>", "HashSetFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.SortedSet<>", "SortedSetFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.Queue<>", "QueueFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.LinkedList<>", "LinkedListFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.SortedList<,>", "SortedListFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.Dictionary<,>", "DictionaryFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.PriorityQueue<,>", "PriorityQueueFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.SortedDictionary<,>", "SortedDictionaryFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Concurrent.ConcurrentBag<>", "ConcurrentBagFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Concurrent.ConcurrentQueue<>", "ConcurrentQueueFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Concurrent.ConcurrentStack<>", "ConcurrentStackFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Concurrent.BlockingCollection<>", "BlockingCollectionFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Concurrent.ConcurrentDictionary<,>", "ConcurrentDictionaryFormatter<TYPEPARAMETER>" },
+        { "System.Collections.ObjectModel.ReadOnlyCollection<>", "ReadOnlyCollectionFormatter" },
+        { "System.Collections.ObjectModel.ReadOnlyDictionary<,>", "ReadOnlyDictionaryFormatter" },
+
+        { "System.Collections.Immutable.ImmutableArray<>", "ImmutableArrayFormatter" },
+        { "System.Collections.Immutable.ImmutableList<>", "ImmutableListFormatter" },
+        { "System.Collections.Immutable.ImmutableStack<>", "ImmutableStackFormatter" },
+        { "System.Collections.Immutable.ImmutableQueue<>", "ImmutableQueueFormatter" },
+        { "System.Collections.Immutable.ImmutableHashSet<>", "ImmutableHashSetFormatter" },
+        { "System.Collections.Immutable.ImmutableSortedSet<>", "ImmutableSortedSetFormatter" },
+        { "System.Collections.Immutable.ImmutableDictionary<,>", "ImmutableDictionaryFormatter" },
+        { "System.Collections.Immutable.ImmutableSortedDictionary<,>", "ImmutableSortedDictionaryFormatter" },
+
+        { "global::System.Collections.Generic.IEnumerable<>", "IEnumerableFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.ICollection<>", "ICollectionFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.IReadOnlyCollection<>", "IReadOnlyCollectionFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.IList<>", "IListFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.IReadOnlyList<>", "IReadOnlyListFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.ISet<>", "ISetFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.IReadOnlySet<>", "IReadOnlySetFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.IDictionary<,>", "IDictionaryFormatter<TYPEPARAMETER>" },
+        { "global::System.Collections.Generic.IReadOnlyDictionary<,>", "IReadOnlyDictionaryFormatter<TYPEPARAMETER>" },
+
+        { "global::System.Collections.Generic.KeyValuePair<,>", "KeyValuePairFormatter<TYPEPARAMETER>" },
+        { "global::System.Tuple<,>", "TupleFormatter<TYPEPARAMETER>" },
+        { "global::System.Tuple<,,>", "TupleFormatter<TYPEPARAMETER>" },
+        { "global::System.Tuple<,,,>", "TupleFormatter<TYPEPARAMETER>" },
+        { "global::System.Tuple<,,,,>", "TupleFormatter<TYPEPARAMETER>" },
+        { "global::System.Tuple<,,,,,>", "TupleFormatter<TYPEPARAMETER>" },
+        { "global::System.Tuple<,,,,,,>", "TupleFormatter<TYPEPARAMETER>" },
+        { "global::System.Tuple<,,,,,,,>", "TupleFormatter<TYPEPARAMETER>" },
+        { "global::System.ValueTuple<,>", "ValueTupleFormatter<TYPEPARAMETER>" },
+        { "global::System.ValueTuple<,,>", "ValueTupleFormatter<TYPEPARAMETER>" },
+        { "global::System.ValueTuple<,,,>", "ValueTupleFormatter<TYPEPARAMETER>" },
+        { "global::System.ValueTuple<,,,,>", "ValueTupleFormatter<TYPEPARAMETER>" },
+        { "global::System.ValueTuple<,,,,,>", "ValueTupleFormatter<TYPEPARAMETER>" },
+        { "global::System.ValueTuple<,,,,,,>", "ValueTupleFormatter<TYPEPARAMETER>" },
+        { "global::System.ValueTuple<,,,,,,,>", "ValueTupleFormatter<TYPEPARAMETER>" },
+
+        { "global::System.Nullable<,>", "NullableStructFormatter<TYPEPARAMETER>" },
+    };
+
+    private static readonly HashSet<string> builtInFormatterTypeMap = new()
+    {
+        "global::System.Half",
+        "global::System.Int128",
+        "global::System.UInt128" ,
+        "global::System.Numerics.BigInteger",
+        "global::System.TimeSpan",
+        "global::System.Uri",
+        "global::System.Guid", 
+        "global::System.Version",
+        "global::System.Text.StringBuilder",
+        "global::System.Collections.BitArray",
+        "global::System.Type",
+    };
+
+    public static bool TryGetGeneratedFormatterType(string formatterType, out string formatter)
+    {
+        return builtInGeneratedFormatterTypes.TryGetValue(formatterType, out formatter);
+    }
+
+    public static bool ContainsBuiltInFormatterType(string typeMetaName)
+        => builtInFormatterTypeMap.Contains(typeMetaName);
+}

--- a/src/CsToml.Generator/Generator.cs
+++ b/src/CsToml.Generator/Generator.cs
@@ -96,7 +96,7 @@ partial {{typeMeta.TypeKeyword}} {{typeMeta.TypeName}} : ITomlSerializedObject<{
 
     static void ITomlSerializedObjectRegister.Register()
     {
-        TomlSerializedObjectFormatterResolver.Register(new TomlSerializedObjectFormatter<{{typeMeta.TypeName}}>());
+{{GenerateRegisterPart(typeMeta)}}
     }
 }
 """;
@@ -201,7 +201,9 @@ partial {{typeMeta.TypeKeyword}} {{typeMeta.TypeName}} : ITomlSerializedObject<{
                 builder.AppendLine($"            writer.PopKey();");
                 builder.AppendLine($"        }}");
             }
-            else if (kind == TomlSerializationKind.ArrayOfITomlSerializedObject || kind == TomlSerializationKind.Dictionary)
+            else if (kind == TomlSerializationKind.ArrayOfITomlSerializedObject ||
+                kind == TomlSerializationKind.CollectionOfITomlSerializedObject ||
+                kind == TomlSerializationKind.Dictionary)
             {
                 builder.AppendLine($"        writer.WriteKey({$"\"{accessName}\"u8"});");
                 builder.AppendLine($"        writer.WriteEqual();");
@@ -220,6 +222,104 @@ partial {{typeMeta.TypeKeyword}} {{typeMeta.TypeName}} : ITomlSerializedObject<{
         }
 
         return builder.ToString();
+    }
+
+    private string GenerateRegisterPart(TypeMeta typeMeta)
+    {
+        var builder = new StringBuilder();
+        foreach (var (type, kind) in typeMeta.DefinedTypes)
+        {
+            switch (kind)
+            {
+                case TomlSerializationKind.Primitive:
+                case TomlSerializationKind.PrimitiveArray:
+                case TomlSerializationKind.TomlSerializedObject:
+                    continue;
+                case TomlSerializationKind.ArrayOfITomlSerializedObject:
+                    var arrayNamedType = (IArrayTypeSymbol)type;
+                    var elementType = arrayNamedType.ElementType;
+
+                    builder.AppendLine($$"""
+        if(!GeneratedFormatterResolver.IsRegistered<{{type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}>())
+        {
+            GeneratedFormatterResolver.Register(new ArrayFormatter<{{elementType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}>());
+        }
+""");
+                    break;
+                case TomlSerializationKind.CollectionOfITomlSerializedObject:
+                    var collectionNamedType = (INamedTypeSymbol)type;
+                    var collectionType = collectionNamedType.ConstructUnboundGenericType();
+                    if (FormatterTypeMetaData.TryGetGeneratedFormatterType(collectionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), out var formatter))
+                    {
+                        var typeParameters = string.Join(",", collectionNamedType.TypeArguments.Select(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+                        formatter = formatter.Replace("TYPEPARAMETER", typeParameters);
+
+                        builder.AppendLine($$"""
+        if(!GeneratedFormatterResolver.IsRegistered<{{type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}>())
+        {
+            GeneratedFormatterResolver.Register(new {{formatter}}());
+        }
+""");
+                    }
+                    break;
+                case TomlSerializationKind.Dictionary:
+                    var dictNamedType = (INamedTypeSymbol)type;
+                    var dictType = dictNamedType.ConstructUnboundGenericType();
+                    if (FormatterTypeMetaData.TryGetGeneratedFormatterType(dictType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), out var dictFormatter))
+                    {
+                        var typeParameters = string.Join(",", dictNamedType.TypeArguments.Select(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+                        dictFormatter = dictFormatter.Replace("TYPEPARAMETER", typeParameters);
+
+                        builder.AppendLine($$"""
+        if(!GeneratedFormatterResolver.IsRegistered<{{type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}>())
+        {
+            GeneratedFormatterResolver.Register(new {{dictFormatter}}());
+        }
+""");
+                    }
+                    break;
+                default:
+                    if (FormatterTypeMetaData.ContainsBuiltInFormatterType(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
+                        break;
+
+                    if (type is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.IsGenericType)
+                    {
+                        var typeSymbol = namedTypeSymbol.ConstructUnboundGenericType();
+                        if (typeSymbol.ToDisplayString() == "T?")
+                        {
+                            builder.AppendLine($$"""
+        if(!GeneratedFormatterResolver.IsRegistered<{{type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}>())
+        {
+            GeneratedFormatterResolver.Register(new NullableFormatter<{{namedTypeSymbol.TypeArguments[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}>());
+        }
+""");
+                            break;
+                        }
+                        if (FormatterTypeMetaData.TryGetGeneratedFormatterType(typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), out var typeFormatter))
+                        {
+                            var typeParameters = string.Join(",", namedTypeSymbol.TypeArguments.Select(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+                            typeFormatter = typeFormatter.Replace("TYPEPARAMETER", typeParameters);
+
+                            builder.AppendLine($$"""
+        if(!GeneratedFormatterResolver.IsRegistered<{{type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}>())
+        {
+            GeneratedFormatterResolver.Register(new {{typeFormatter}}());
+        }
+""");
+                            break;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        var code = $$"""
+        TomlSerializedObjectFormatterResolver.Register(new TomlSerializedObjectFormatter<{{typeMeta.TypeName}}>());
+
+        // Register Formatter in advance.
+{{builder}}
+""";
+        return code;
     }
 }
 

--- a/src/CsToml.Generator/SymbolUtility.cs
+++ b/src/CsToml.Generator/SymbolUtility.cs
@@ -71,7 +71,7 @@ internal static class SymbolUtility
                 {
                     return TomlSerializationKind.PrimitiveCollection;
                 }
-                return TomlSerializationKind.ArrayOfITomlSerializedObject;
+                return TomlSerializationKind.CollectionOfITomlSerializedObject;
             default:
                 switch (type.TypeKind)
                 {
@@ -92,21 +92,9 @@ internal static class SymbolUtility
                             {
                                 return TomlSerializationKind.PrimitiveCollection;
                             }
-                            return TomlSerializationKind.ArrayOfITomlSerializedObject;
+                            return TomlSerializationKind.CollectionOfITomlSerializedObject;
                         }
                         if (DictionaryMetaData.IsDictionaryClass(type))
-                        {
-                            return TomlSerializationKind.Dictionary;
-                        }
-                        if (CollectionMetaData.IsSystemCollections(type))
-                        {
-                            if (IsElementType(type, TomlSerializationKind.Primitive))
-                            {
-                                return TomlSerializationKind.PrimitiveCollection;
-                            }
-                            return TomlSerializationKind.ArrayOfITomlSerializedObject;
-                        }
-                        if (DictionaryMetaData.IsDictionary(type))
                         {
                             return TomlSerializationKind.Dictionary;
                         }
@@ -122,7 +110,7 @@ internal static class SymbolUtility
                             {
                                 return TomlSerializationKind.PrimitiveCollection;
                             }
-                            return TomlSerializationKind.ArrayOfITomlSerializedObject;
+                            return TomlSerializationKind.CollectionOfITomlSerializedObject;
                         }
                         if (DictionaryMetaData.IsDictionary(type))
                         {
@@ -130,6 +118,17 @@ internal static class SymbolUtility
                         }
                         return TomlSerializationKind.Interface;
                     case TypeKind.Struct:
+                        switch(type.MetadataName)
+                        {
+                            case "DateTimeOffset":
+                            case "DateOnly":
+                            case "TimeOnly":
+                                return TomlSerializationKind.Primitive;
+                        }
+                        if (TomlSerializedObjectMetaData.IsTomlSerializedObject(type))
+                        {
+                            return TomlSerializationKind.TomlSerializedObject;
+                        }
                         return TomlSerializationKind.Struct;
                 }
 
@@ -144,6 +143,17 @@ internal static class SymbolUtility
             var symbolKind = GetTomlSerializationKind(arrayTypeSymbol.ElementType);
             return symbolKind == kind;
         }
+
+        //if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
+        //{
+        //    var typeArguments = namedTypeSymbol.TypeArguments;
+        //    if (typeArguments.Length == 1)
+        //    {
+        //        var symbolKind = GetTomlSerializationKind(typeArguments[0]);
+        //        return symbolKind == kind;
+        //    }
+        //    return false;
+        //}
 
         return false;
     }

--- a/src/CsToml.Generator/TomlSerializationKind.cs
+++ b/src/CsToml.Generator/TomlSerializationKind.cs
@@ -13,6 +13,7 @@ internal enum TomlSerializationKind
     Dictionary,
     Object,
     ArrayOfITomlSerializedObject,
+    CollectionOfITomlSerializedObject,
     TomlSerializedObject,
     Error
 }

--- a/src/CsToml/CsToml.csproj
+++ b/src/CsToml/CsToml.csproj
@@ -7,6 +7,7 @@
     <Description>TOML Serializer for .NET.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>TOML,serializer,parser,writer,reader</PackageTags>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CsToml/CsTomlSerializer.cs
+++ b/src/CsToml/CsTomlSerializer.cs
@@ -4,6 +4,7 @@ using CsToml.Formatter.Resolver;
 using CsToml.Utility;
 using CsToml.Values;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace CsToml;
@@ -41,7 +42,7 @@ public static class CsTomlSerializer
         }
     }
 
-    private static ITomlValueFormatter<T> GetFormatter<T>(TomlDocument? tomlDocument)
+    private static ITomlValueFormatter<T> GetFormatter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(TomlDocument? tomlDocument)
     {
         if (typeof(T) == typeof(TomlDocument))
         {
@@ -52,7 +53,7 @@ public static class CsTomlSerializer
         return TomlValueFormatterResolver.Instance.GetFormatter<T>()!;
     }
 
-    public static T Deserialize<T>(ReadOnlySpan<byte> tomlText, CsTomlSerializerOptions? options = null)
+    public static T Deserialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ReadOnlySpan<byte> tomlText, CsTomlSerializerOptions? options = null)
     {
         options ??= DefaultOptions;
 
@@ -75,7 +76,7 @@ public static class CsTomlSerializer
         }
     }
 
-    public static T Deserialize<T>(ReadOnlySequence<byte> tomlSequence, CsTomlSerializerOptions? options = null)
+    public static T Deserialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ReadOnlySequence<byte> tomlSequence, CsTomlSerializerOptions? options = null)
     {
         options ??= DefaultOptions;
 
@@ -98,7 +99,7 @@ public static class CsTomlSerializer
         }
     }
 
-    public static T Deserialize<T>(Stream stream, CsTomlSerializerOptions? options = null)
+    public static T Deserialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Stream stream, CsTomlSerializerOptions? options = null)
     {
         if (stream is MemoryStream memoryStream && memoryStream.TryGetBuffer(out var arraySegment))
         {
@@ -119,7 +120,7 @@ public static class CsTomlSerializer
         return Deserialize<T>(bufferWriter.CreateReadOnlySequence(), options);
     }
 
-    public static async ValueTask<T> DeserializeAsync<T>(Stream stream, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
+    public static async ValueTask<T> DeserializeAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Stream stream, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
     {
         if (stream is MemoryStream memoryStream && memoryStream.TryGetBuffer(out var arraySegment))
         {
@@ -140,7 +141,7 @@ public static class CsTomlSerializer
         return Deserialize<T>(bufferWriter.CreateReadOnlySequence(), options);
     }
 
-    public static T DeserializeValueType<T>(ReadOnlySpan<byte> tomlText, CsTomlSerializerOptions? options = null)
+    public static T DeserializeValueType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ReadOnlySpan<byte> tomlText, CsTomlSerializerOptions? options = null)
     {
         options ??= DefaultOptions;
         var utf8SequenceReader = new Utf8SequenceReader(tomlText, true);
@@ -151,7 +152,7 @@ public static class CsTomlSerializer
         return options.Resolver.GetFormatter<T>()!.Deserialize(ref tomlDocumentNode, options);
     }
 
-    public static T DeserializeValueType<T>(ReadOnlySequence<byte> tomlSequence, CsTomlSerializerOptions? options = null)
+    public static T DeserializeValueType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ReadOnlySequence<byte> tomlSequence, CsTomlSerializerOptions? options = null)
     {
         options ??= DefaultOptions;
         var utf8SequenceReader = new Utf8SequenceReader(tomlSequence, true);
@@ -162,7 +163,7 @@ public static class CsTomlSerializer
         return options.Resolver.GetFormatter<T>()!.Deserialize(ref tomlDocumentNode, options);
     }
 
-    public static ByteMemoryResult Serialize<T>(T target, CsTomlSerializerOptions? options = null)
+    public static ByteMemoryResult Serialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T target, CsTomlSerializerOptions? options = null)
     {
         var bufferWriter = RecycleArrayPoolBufferWriter<byte>.Rent();
         try
@@ -176,7 +177,7 @@ public static class CsTomlSerializer
         }
     }
 
-    public static void Serialize<TBufferWriter, T>(ref TBufferWriter bufferWriter, T target, CsTomlSerializerOptions? options = null)
+    public static void Serialize<TBufferWriter, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ref TBufferWriter bufferWriter, T target, CsTomlSerializerOptions? options = null)
         where TBufferWriter : IBufferWriter<byte>
     {
         options ??= DefaultOptions;
@@ -195,7 +196,7 @@ public static class CsTomlSerializer
         }
     }
 
-    public static void Serialize<T>(Stream stream, T value, CsTomlSerializerOptions? options = null)
+    public static void Serialize<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Stream stream, T value, CsTomlSerializerOptions? options = null)
     {
         using var bufferWriter = new ByteBufferSegmentWriter();
         var tempWriter = bufferWriter;
@@ -205,7 +206,7 @@ public static class CsTomlSerializer
         bufferWriter.WriteTo(streamByteWriter.ByteWriter);
     }
 
-    public static async ValueTask SerializeAsync<T>(Stream stream, T value, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
+    public static async ValueTask SerializeAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(Stream stream, T value, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -217,7 +218,7 @@ public static class CsTomlSerializer
         await bufferWriter.WriteToAsync(streamByteWriter.ByteWriter, configureAwait, cancellationToken);
     }
 
-    public static ByteMemoryResult SerializeValueType<T>(T target, CsTomlSerializerOptions? options = null)
+    public static ByteMemoryResult SerializeValueType<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(T target, CsTomlSerializerOptions? options = null)
     {
         var bufferWriter = RecycleArrayPoolBufferWriter<byte>.Rent();
         try
@@ -231,7 +232,7 @@ public static class CsTomlSerializer
         }
     }
 
-    public static void SerializeValueType<TBufferWriter, T>(ref TBufferWriter bufferWriter, T target, CsTomlSerializerOptions? options = null)
+    public static void SerializeValueType<TBufferWriter, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ref TBufferWriter bufferWriter, T target, CsTomlSerializerOptions? options = null)
         where TBufferWriter : IBufferWriter<byte>
     {
         options ??= DefaultOptions;

--- a/src/CsToml/Formatter/ArrayBaseFormatter.cs
+++ b/src/CsToml/Formatter/ArrayBaseFormatter.cs
@@ -1,10 +1,9 @@
 ﻿using CsToml.Error;
-using CsToml.Formatter.Resolver;
 using System.Buffers;
 
 namespace CsToml.Formatter;
 
-internal abstract class ArrayBaseFormatter<TArray, TElement> : ITomlValueFormatter<TArray?>
+public abstract class ArrayBaseFormatter<TArray, TElement> : ITomlValueFormatter<TArray?>
 {
     public TArray? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {

--- a/src/CsToml/Formatter/ArrayFormatter.cs
+++ b/src/CsToml/Formatter/ArrayFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class ArrayFormatter<T> : ArrayBaseFormatter<T[], T>
+public sealed class ArrayFormatter<T> : ArrayBaseFormatter<T[], T>
 {
     protected override ReadOnlySpan<T> AsSpan(T[] array)
     {

--- a/src/CsToml/Formatter/ArrayListFormatter.cs
+++ b/src/CsToml/Formatter/ArrayListFormatter.cs
@@ -5,7 +5,7 @@ using System.Collections;
 
 namespace CsToml.Formatter;
 
-internal sealed class ArrayListFormatter : ITomlValueFormatter<ArrayList?>
+public sealed class ArrayListFormatter : ITomlValueFormatter<ArrayList?>
 {
     public static readonly ArrayListFormatter Instance = new ArrayListFormatter();
 

--- a/src/CsToml/Formatter/BlockingCollectionFormatter.cs
+++ b/src/CsToml/Formatter/BlockingCollectionFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class BlockingCollectionFormatter<T> : CollectionBaseFormatter<BlockingCollection<T>, T, BlockingCollection<T>>
+public sealed class BlockingCollectionFormatter<T> : CollectionBaseFormatter<BlockingCollection<T>, T, BlockingCollection<T>>
 {
     protected override void AddValue(BlockingCollection<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/CollectionBaseFormatter.cs
+++ b/src/CsToml/Formatter/CollectionBaseFormatter.cs
@@ -1,10 +1,9 @@
 ﻿using CsToml.Error;
-using CsToml.Formatter.Resolver;
 using System.Buffers;
 
 namespace CsToml.Formatter;
 
-internal abstract class CollectionBaseFormatter<TCollection, TElement, TMediator> : ITomlValueFormatter<TCollection?>
+public abstract class CollectionBaseFormatter<TCollection, TElement, TMediator> : ITomlValueFormatter<TCollection?>
     where TCollection : IEnumerable<TElement>
 {
     public TCollection? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)

--- a/src/CsToml/Formatter/ConcurrentBagFormatter.cs
+++ b/src/CsToml/Formatter/ConcurrentBagFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ConcurrentBagFormatter<T> : CollectionBaseFormatter<ConcurrentBag<T>, T, List<T>>
+public sealed class ConcurrentBagFormatter<T> : CollectionBaseFormatter<ConcurrentBag<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ConcurrentDictionaryFormatter.cs
+++ b/src/CsToml/Formatter/ConcurrentDictionaryFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal class ConcurrentDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, ConcurrentDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
+public class ConcurrentDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, ConcurrentDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(Dictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/ConcurrentQueueFormatter.cs
+++ b/src/CsToml/Formatter/ConcurrentQueueFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ConcurrentQueueFormatter<T> : CollectionBaseFormatter<ConcurrentQueue<T>, T, ConcurrentQueue<T>>
+public sealed class ConcurrentQueueFormatter<T> : CollectionBaseFormatter<ConcurrentQueue<T>, T, ConcurrentQueue<T>>
 {
     protected override void AddValue(ConcurrentQueue<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ConcurrentStackFormatter.cs
+++ b/src/CsToml/Formatter/ConcurrentStackFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ConcurrentStackFormatter<T> : CollectionBaseFormatter<ConcurrentStack<T>, T, List<T>>
+public sealed class ConcurrentStackFormatter<T> : CollectionBaseFormatter<ConcurrentStack<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/DictionaryBaseFormatter.cs
+++ b/src/CsToml/Formatter/DictionaryBaseFormatter.cs
@@ -5,7 +5,7 @@ using System.Buffers;
 
 namespace CsToml.Formatter;
 
-internal abstract class DictionaryBaseFormatter<TKey, TValue, TDicitonary, TMediator> : ITomlValueFormatter<TDicitonary>
+public abstract class DictionaryBaseFormatter<TKey, TValue, TDicitonary, TMediator> : ITomlValueFormatter<TDicitonary>
     where TDicitonary : IEnumerable<KeyValuePair<TKey, TValue>>
 {
     public TDicitonary Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)

--- a/src/CsToml/Formatter/DictionaryFormatter.cs
+++ b/src/CsToml/Formatter/DictionaryFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class DictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, Dictionary<TKey, TValue>, Dictionary<TKey, TValue>>
+public sealed class DictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, Dictionary<TKey, TValue>, Dictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(Dictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/EnumFormatter.cs
+++ b/src/CsToml/Formatter/EnumFormatter.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 
 namespace CsToml.Formatter;
 
-internal sealed class EnumFormatter<TEnum> : ITomlValueFormatter<TEnum>
+public sealed class EnumFormatter<TEnum> : ITomlValueFormatter<TEnum>
     where TEnum : Enum
 {
     private static readonly Dictionary<TEnum, string>? SerializedEnumTable;

--- a/src/CsToml/Formatter/HashSetFormatter.cs
+++ b/src/CsToml/Formatter/HashSetFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class HashSetFormatter<T> : CollectionBaseFormatter<HashSet<T>, T, HashSet<T>>
+public sealed class HashSetFormatter<T> : CollectionBaseFormatter<HashSet<T>, T, HashSet<T>>
 {
     protected override void AddValue(HashSet<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ICollectionFormatter.cs
+++ b/src/CsToml/Formatter/ICollectionFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class ICollectionFormatter<T> : CollectionBaseFormatter<ICollection<T>, T, List<T>>
+public sealed class ICollectionFormatter<T> : CollectionBaseFormatter<ICollection<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/IDictionaryFormatter.cs
+++ b/src/CsToml/Formatter/IDictionaryFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class IDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, IDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
+public sealed class IDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, IDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(Dictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/IEnumerableFormatter.cs
+++ b/src/CsToml/Formatter/IEnumerableFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class IEnumerableFormatter<T> : CollectionBaseFormatter<IEnumerable<T>, T, List<T>>
+public sealed class IEnumerableFormatter<T> : CollectionBaseFormatter<IEnumerable<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/IListFormatter.cs
+++ b/src/CsToml/Formatter/IListFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class IListFormatter<T> : CollectionBaseFormatter<IList<T>, T, List<T>>
+public sealed class IListFormatter<T> : CollectionBaseFormatter<IList<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/IReadOnlyCollectionFormatter.cs
+++ b/src/CsToml/Formatter/IReadOnlyCollectionFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class IReadOnlyCollectionFormatter<T> : CollectionBaseFormatter<IReadOnlyCollection<T>, T, List<T>>
+public sealed class IReadOnlyCollectionFormatter<T> : CollectionBaseFormatter<IReadOnlyCollection<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/IReadOnlyDictionaryFormatter.cs
+++ b/src/CsToml/Formatter/IReadOnlyDictionaryFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class IReadOnlyDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, IReadOnlyDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
+public sealed class IReadOnlyDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, IReadOnlyDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(Dictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/IReadOnlyListFormatter.cs
+++ b/src/CsToml/Formatter/IReadOnlyListFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class IReadOnlyListFormatter<T> : CollectionBaseFormatter<IReadOnlyList<T>, T, List<T>>
+public sealed class IReadOnlyListFormatter<T> : CollectionBaseFormatter<IReadOnlyList<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/IReadOnlySetFormatter.cs
+++ b/src/CsToml/Formatter/IReadOnlySetFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class IReadOnlySetFormatter<T> : CollectionBaseFormatter<IReadOnlySet<T>, T, HashSet<T>>
+public sealed class IReadOnlySetFormatter<T> : CollectionBaseFormatter<IReadOnlySet<T>, T, HashSet<T>>
 {
     protected override void AddValue(HashSet<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ISetFormatter.cs
+++ b/src/CsToml/Formatter/ISetFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class ISetFormatter<T> : CollectionBaseFormatter<ISet<T>, T, HashSet<T>>
+public sealed class ISetFormatter<T> : CollectionBaseFormatter<ISet<T>, T, HashSet<T>>
 {
     protected override void AddValue(HashSet<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ImmutableArrayFormatter.cs
+++ b/src/CsToml/Formatter/ImmutableArrayFormatter.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace CsToml.Formatter;
 
-internal sealed class ImmutableArrayFormatter<T> : ArrayBaseFormatter<ImmutableArray<T>, T>
+public sealed class ImmutableArrayFormatter<T> : ArrayBaseFormatter<ImmutableArray<T>, T>
 {
     protected override ReadOnlySpan<T> AsSpan(ImmutableArray<T> array)
     {

--- a/src/CsToml/Formatter/ImmutableDictionaryFormatter.cs
+++ b/src/CsToml/Formatter/ImmutableDictionaryFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ImmutableDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, ImmutableDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
+public sealed class ImmutableDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, ImmutableDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(Dictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/ImmutableHashSetFormatter.cs
+++ b/src/CsToml/Formatter/ImmutableHashSetFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ImmutableHashSetFormatter<T> : CollectionBaseFormatter<ImmutableHashSet<T>, T, HashSet<T>>
+public sealed class ImmutableHashSetFormatter<T> : CollectionBaseFormatter<ImmutableHashSet<T>, T, HashSet<T>>
 {
     protected override void AddValue(HashSet<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ImmutableListFormatter.cs
+++ b/src/CsToml/Formatter/ImmutableListFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ImmutableListFormatter<T> : CollectionBaseFormatter<ImmutableList<T>, T, List<T>>
+public sealed class ImmutableListFormatter<T> : CollectionBaseFormatter<ImmutableList<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ImmutableQueueFormatter.cs
+++ b/src/CsToml/Formatter/ImmutableQueueFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ImmutableQueueFormatter<T> : CollectionBaseFormatter<ImmutableQueue<T>, T, Queue<T>>
+public sealed class ImmutableQueueFormatter<T> : CollectionBaseFormatter<ImmutableQueue<T>, T, Queue<T>>
 {
     protected override void AddValue(Queue<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ImmutableSortedDictionaryFormatter.cs
+++ b/src/CsToml/Formatter/ImmutableSortedDictionaryFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ImmutableSortedDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, ImmutableSortedDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
+public sealed class ImmutableSortedDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, ImmutableSortedDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(Dictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/ImmutableSortedSetFormatter.cs
+++ b/src/CsToml/Formatter/ImmutableSortedSetFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ImmutableSortedSetFormatter<T> : CollectionBaseFormatter<ImmutableSortedSet<T>, T, SortedSet<T>>
+public sealed class ImmutableSortedSetFormatter<T> : CollectionBaseFormatter<ImmutableSortedSet<T>, T, SortedSet<T>>
 {
     protected override void AddValue(SortedSet<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ImmutableStackFormatter.cs
+++ b/src/CsToml/Formatter/ImmutableStackFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ImmutableStackFormatter<T> : CollectionBaseFormatter<ImmutableStack<T>, T, List<T>>
+public sealed class ImmutableStackFormatter<T> : CollectionBaseFormatter<ImmutableStack<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/KeyValuePairFormatter.cs
+++ b/src/CsToml/Formatter/KeyValuePairFormatter.cs
@@ -1,11 +1,9 @@
 ﻿using CsToml.Error;
-using CsToml.Formatter.Resolver;
 using System.Buffers;
-using System.Xml.Linq;
 
 namespace CsToml.Formatter;
 
-internal sealed class KeyValuePairFormatter<TKey, TValue> : ITomlValueFormatter<KeyValuePair<TKey, TValue>>
+public sealed class KeyValuePairFormatter<TKey, TValue> : ITomlValueFormatter<KeyValuePair<TKey, TValue>>
 {
     public KeyValuePair<TKey, TValue> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {

--- a/src/CsToml/Formatter/LinkedListFormatter.cs
+++ b/src/CsToml/Formatter/LinkedListFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class LinkedListFormatter<T> : CollectionBaseFormatter<LinkedList<T>, T, LinkedList<T>>
+public sealed class LinkedListFormatter<T> : CollectionBaseFormatter<LinkedList<T>, T, LinkedList<T>>
 {
     protected override void AddValue(LinkedList<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ListFormatter.cs
+++ b/src/CsToml/Formatter/ListFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class ListFormatter<T> : CollectionBaseFormatter<List<T>, T, List<T>>
+public sealed class ListFormatter<T> : CollectionBaseFormatter<List<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/MemoryFormatter.cs
+++ b/src/CsToml/Formatter/MemoryFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class MemoryFormatter<T> : ArrayBaseFormatter<Memory<T>, T>
+public sealed class MemoryFormatter<T> : ArrayBaseFormatter<Memory<T>, T>
 {
     protected override ReadOnlySpan<T> AsSpan(Memory<T> array)
     {

--- a/src/CsToml/Formatter/NullableFormatter.cs
+++ b/src/CsToml/Formatter/NullableFormatter.cs
@@ -1,10 +1,9 @@
 ﻿using CsToml.Error;
-using CsToml.Formatter.Resolver;
 using System.Buffers;
 
 namespace CsToml.Formatter;
 
-internal sealed class NullableStructFormatter<T> : ITomlValueFormatter<T?>
+public sealed class NullableFormatter<T> : ITomlValueFormatter<T?>
     where T : struct
 {
     public T? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)

--- a/src/CsToml/Formatter/OrderedDictionaryFormatter.cs
+++ b/src/CsToml/Formatter/OrderedDictionaryFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class OrderedDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, OrderedDictionary<TKey, TValue>, OrderedDictionary<TKey, TValue>>
+public sealed class OrderedDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, OrderedDictionary<TKey, TValue>, OrderedDictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(OrderedDictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/PrimitiveObjectFormatter.cs
+++ b/src/CsToml/Formatter/PrimitiveObjectFormatter.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 
 namespace CsToml.Formatter;
 
-internal sealed class PrimitiveObjectFormatter : ITomlValueFormatter<object>
+public sealed class PrimitiveObjectFormatter : ITomlValueFormatter<object>
 {
     public static readonly PrimitiveObjectFormatter Instance = new PrimitiveObjectFormatter();
 

--- a/src/CsToml/Formatter/PriorityQueueFormatter.cs
+++ b/src/CsToml/Formatter/PriorityQueueFormatter.cs
@@ -3,7 +3,7 @@ using System.Buffers;
 
 namespace CsToml.Formatter;
 
-internal sealed class PriorityQueueFormatter<TElement, TPriority> : ITomlValueFormatter<PriorityQueue<TElement, TPriority>>
+public sealed class PriorityQueueFormatter<TElement, TPriority> : ITomlValueFormatter<PriorityQueue<TElement, TPriority>>
 {
     public PriorityQueue<TElement, TPriority> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {

--- a/src/CsToml/Formatter/QueueFormatter.cs
+++ b/src/CsToml/Formatter/QueueFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class QueueFormatter<T> : CollectionBaseFormatter<Queue<T>, T, Queue<T>>
+public sealed class QueueFormatter<T> : CollectionBaseFormatter<Queue<T>, T, Queue<T>>
 {
     protected override void AddValue(Queue<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ReadOnlyCollectionFormatter.cs
+++ b/src/CsToml/Formatter/ReadOnlyCollectionFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ReadOnlyCollectionFormatter<T> : CollectionBaseFormatter<ReadOnlyCollection<T>, T, List<T>>
+public sealed class ReadOnlyCollectionFormatter<T> : CollectionBaseFormatter<ReadOnlyCollection<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/ReadOnlyDictionaryFormatter.cs
+++ b/src/CsToml/Formatter/ReadOnlyDictionaryFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace CsToml.Formatter;
 
-internal sealed class ReadOnlyDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, ReadOnlyDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
+public sealed class ReadOnlyDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, ReadOnlyDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(Dictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/ReadOnlyMemoryFormatter.cs
+++ b/src/CsToml/Formatter/ReadOnlyMemoryFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class ReadOnlyMemoryFormatter<T> : ArrayBaseFormatter<ReadOnlyMemory<T>, T>
+public sealed class ReadOnlyMemoryFormatter<T> : ArrayBaseFormatter<ReadOnlyMemory<T>, T>
 {
     protected override ReadOnlySpan<T> AsSpan(ReadOnlyMemory<T> array)
     {

--- a/src/CsToml/Formatter/ReadOnlySetFormatter.cs
+++ b/src/CsToml/Formatter/ReadOnlySetFormatter.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 
 namespace CsToml.Formatter;
 
-internal class ReadOnlySetFormatter<T> : CollectionBaseFormatter<ReadOnlySet<T>, T, HashSet<T>>
+public class ReadOnlySetFormatter<T> : CollectionBaseFormatter<ReadOnlySet<T>, T, HashSet<T>>
 {
     protected override void AddValue(HashSet<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/Resolver/BuiltinFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/BuiltinFormatterResolver.cs
@@ -1,6 +1,7 @@
 ﻿
 using System.Collections;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace CsToml.Formatter.Resolver;
@@ -220,6 +221,7 @@ internal sealed class BuiltinFormatterResolver : ITomlValueFormatterResolver
 
     internal static readonly BuiltinFormatterResolver Instance = new BuiltinFormatterResolver();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ITomlValueFormatter<T>? GetFormatter<T>()
     {
         var formatter = DefaultFormatterCache<T>.Formatter;
@@ -227,4 +229,8 @@ internal sealed class BuiltinFormatterResolver : ITomlValueFormatterResolver
             return formatter;
         return null;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsRegistered<T>()
+        => CacheCheck<T>.Registered;
 }

--- a/src/CsToml/Formatter/Resolver/BuiltinFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/BuiltinFormatterResolver.cs
@@ -1,98 +1,23 @@
 ﻿
 using System.Collections;
-using System.Collections.Concurrent;
-using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 using System.Numerics;
 using System.Text;
 
 namespace CsToml.Formatter.Resolver;
 
-internal sealed class BuildinFormatterResolver : ITomlValueFormatterResolver
+internal sealed class BuiltinFormatterResolver : ITomlValueFormatterResolver
 {
+    private sealed class CacheCheck<T>
+    {
+        public static bool Registered;
+    }
+
     private sealed class DefaultFormatterCache<T>
     {
         public static ITomlValueFormatter<T>? Formatter;
     }
 
-    private sealed class ArrayFormatterCache<T>
-    {
-        public static ITomlValueFormatter<T>? Formatter = GetArrayFormatter<T>() as ITomlValueFormatter<T>;
-    }
-
-    private sealed class GeneratedFormatterCache<T>
-    {
-        public static ITomlValueFormatter<T>? Formatter = GetGenericTypeFormatter<T>() as ITomlValueFormatter<T>;
-    }
-
-    private static readonly Dictionary<Type, Type> formatterTypeTable = new()
-    {
-        { typeof(Nullable<>), typeof(NullableStructFormatter<>) },
-        { typeof(Memory<>),  typeof(MemoryFormatter<>) },
-        { typeof(ReadOnlyMemory<>),  typeof(ReadOnlyMemoryFormatter<>) },
-
-        { typeof(List<>), typeof(ListFormatter<>) },
-        { typeof(Stack<>), typeof(StackFormatter<>) },
-        { typeof(HashSet<>), typeof(HashSetFormatter<>) },
-        { typeof(SortedSet<>), typeof(SortedSetFormatter<>) },
-        { typeof(Queue<>), typeof(QueueFormatter<>) },
-        { typeof(LinkedList<>), typeof(LinkedListFormatter<>) },
-        { typeof(SortedList<,>), typeof(SortedListFormatter<,>) },
-        { typeof(ConcurrentQueue<>), typeof(ConcurrentQueueFormatter<>) },
-        { typeof(ConcurrentStack<>), typeof(ConcurrentStackFormatter<>) },
-        { typeof(ConcurrentBag<>), typeof(ConcurrentBagFormatter<>) },
-        { typeof(ReadOnlyCollection<>), typeof(ReadOnlyCollectionFormatter<>) },
-        { typeof(BlockingCollection<>), typeof(BlockingCollectionFormatter<>) },
-        { typeof(PriorityQueue<,>), typeof(PriorityQueueFormatter<,>) },
-        { typeof(Dictionary<,>), typeof(DictionaryFormatter<,>) },
-        { typeof(ReadOnlyDictionary<,>), typeof(ReadOnlyDictionaryFormatter<,>) },
-        { typeof(SortedDictionary<,>), typeof(SortedDictionaryFormatter<,>) },
-        { typeof(ConcurrentDictionary<,>), typeof(ConcurrentDictionaryFormatter<,>) },
-
-        { typeof(ImmutableArray<>), typeof(ImmutableArrayFormatter<>) },
-        { typeof(ImmutableList<>), typeof(ImmutableListFormatter<>) },
-        { typeof(ImmutableStack<>), typeof(ImmutableStackFormatter<>) },
-        { typeof(ImmutableQueue<>), typeof(ImmutableQueueFormatter<>)},
-        { typeof(ImmutableHashSet<>), typeof(ImmutableHashSetFormatter<>) },
-        { typeof(ImmutableSortedSet<>), typeof(ImmutableSortedSetFormatter<>) },
-        { typeof(ImmutableDictionary<,>), typeof(ImmutableDictionaryFormatter<,>) },
-        { typeof(ImmutableSortedDictionary<,>), typeof(ImmutableSortedDictionaryFormatter<,>) },
-
-        { typeof(IEnumerable<>), typeof(IEnumerableFormatter<>) },
-        { typeof(ICollection<>),  typeof(ICollectionFormatter<>) },
-        { typeof(IReadOnlyCollection<>),  typeof(IReadOnlyCollectionFormatter<>) },
-        { typeof(IList<>),  typeof(IListFormatter<>) },
-        { typeof(IReadOnlyList<>),  typeof(IReadOnlyListFormatter<>) },
-        { typeof(ISet<>),  typeof(ISetFormatter<>) },
-        { typeof(IReadOnlySet<>),  typeof(IReadOnlySetFormatter<>) },
-        { typeof(IDictionary<,>),typeof(IDictionaryFormatter<,>) },
-        { typeof(IReadOnlyDictionary<,>),typeof(IReadOnlyDictionaryFormatter<,>) },
-
-        { typeof(KeyValuePair<,>),  typeof(KeyValuePairFormatter<,>) },
-        { typeof(Tuple<>),  typeof(TupleFormatter<>) },
-        { typeof(Tuple<,>),  typeof(TupleFormatter<,>) },
-        { typeof(Tuple<,,>),  typeof(TupleFormatter<,,>) },
-        { typeof(Tuple<,,,>),  typeof(TupleFormatter<,,,>) },
-        { typeof(Tuple<,,,,>),  typeof(TupleFormatter<,,,,>) },
-        { typeof(Tuple<,,,,,>),  typeof(TupleFormatter<,,,,,>) },
-        { typeof(Tuple<,,,,,,>),  typeof(TupleFormatter<,,,,,,>) },
-        { typeof(Tuple<,,,,,,,>),  typeof(TupleFormatter<,,,,,,,>) },
-        { typeof(ValueTuple<>),  typeof(ValueTupleFormatter<>) },
-        { typeof(ValueTuple<,>),  typeof(ValueTupleFormatter<,>) },
-        { typeof(ValueTuple<,,>),  typeof(ValueTupleFormatter<,,>) },
-        { typeof(ValueTuple<,,,>),  typeof(ValueTupleFormatter<,,,>) },
-        { typeof(ValueTuple<,,,,>),  typeof(ValueTupleFormatter<,,,,>) },
-        { typeof(ValueTuple<,,,,,>),  typeof(ValueTupleFormatter<,,,,,>) },
-        { typeof(ValueTuple<,,,,,,>),  typeof(ValueTupleFormatter<,,,,,,>) },
-        { typeof(ValueTuple<,,,,,,,>),  typeof(ValueTupleFormatter<,,,,,,,>) },
-
-#if NET9_0_OR_GREATER
-        { typeof(OrderedDictionary<,>), typeof(OrderedDictionaryFormatter<,>) },
-        { typeof(ReadOnlySet<>), typeof(ReadOnlySetFormatter<>) },
-#endif
-    };
-
-    static BuildinFormatterResolver()
+    static BuiltinFormatterResolver()
     {
         DefaultFormatterCache<bool>.Formatter = BooleanFormatter.Instance;
         DefaultFormatterCache<bool?>.Formatter = NullableBooleanFormatter.Instance;
@@ -189,53 +114,117 @@ internal sealed class BuildinFormatterResolver : ITomlValueFormatterResolver
 
         DefaultFormatterCache<Hashtable>.Formatter = HashtableFormatter.Instance;
         DefaultFormatterCache<ArrayList?>.Formatter = ArrayListFormatter.Instance;
+
+        DefaultFormatterCache<IDictionary<string, object?>>.Formatter = new IDictionaryFormatter<string, object?>();
+        DefaultFormatterCache<IDictionary<object, object?>>.Formatter = new IDictionaryFormatter<object, object?>();
+
+        CacheCheck<bool>.Registered = true;
+        CacheCheck<bool?>.Registered = true;
+        CacheCheck<byte>.Registered = true;
+        CacheCheck<byte?>.Registered = true;
+        CacheCheck<sbyte>.Registered = true;
+        CacheCheck<sbyte?>.Registered = true;
+        CacheCheck<char>.Registered = true;
+        CacheCheck<char?>.Registered = true;
+        CacheCheck<float>.Registered = true;
+        CacheCheck<float?>.Registered = true;
+        CacheCheck<double>.Registered = true;
+        CacheCheck<double?>.Registered = true;
+        CacheCheck<short>.Registered = true;
+        CacheCheck<short?>.Registered = true;
+        CacheCheck<ushort>.Registered = true;
+        CacheCheck<ushort?>.Registered = true;
+        CacheCheck<int>.Registered = true;
+        CacheCheck<int?>.Registered = true;
+        CacheCheck<uint>.Registered = true;
+        CacheCheck<uint?>.Registered = true;
+        CacheCheck<long>.Registered = true;
+        CacheCheck<long?>.Registered = true;
+        CacheCheck<ulong>.Registered = true;
+        CacheCheck<ulong?>.Registered = true;
+
+        CacheCheck<DateTimeOffset>.Registered = true;
+        CacheCheck<DateTimeOffset?>.Registered = true;
+        CacheCheck<DateTime>.Registered = true;
+        CacheCheck<DateTime?>.Registered = true;
+        CacheCheck<DateOnly>.Registered = true;
+        CacheCheck<DateOnly?>.Registered = true;
+        CacheCheck<TimeOnly>.Registered = true;
+        CacheCheck<TimeOnly?>.Registered = true;
+        CacheCheck<string?>.Registered = true;
+        CacheCheck<decimal>.Registered = true;
+        CacheCheck<decimal?>.Registered = true;
+        CacheCheck<Half>.Registered = true;
+        CacheCheck<Half?>.Registered = true;
+        CacheCheck<Int128>.Registered = true;
+        CacheCheck<Int128?>.Registered = true;
+        CacheCheck<UInt128>.Registered = true;
+        CacheCheck<UInt128?>.Registered = true;
+        CacheCheck<BigInteger>.Registered = true;
+        CacheCheck<BigInteger?>.Registered = true;
+        CacheCheck<TimeSpan>.Registered = true;
+        CacheCheck<TimeSpan?>.Registered = true;
+
+        CacheCheck<Uri?>.Registered = true;
+        CacheCheck<Guid>.Registered = true;
+        CacheCheck<Guid?>.Registered = true;
+        CacheCheck<Version?>.Registered = true;
+        CacheCheck<StringBuilder?>.Registered = true;
+        CacheCheck<BitArray?>.Registered = true;
+        CacheCheck<Type?>.Registered = true;
+
+        CacheCheck<bool[]?>.Registered = true;
+        CacheCheck<byte[]?>.Registered = true;
+        CacheCheck<sbyte[]?>.Registered = true;
+        CacheCheck<short[]?>.Registered = true;
+        CacheCheck<ushort[]?>.Registered = true;
+        CacheCheck<int[]?>.Registered = true;
+        CacheCheck<uint[]?>.Registered = true;
+        CacheCheck<long[]?>.Registered = true;
+        CacheCheck<ulong[]?>.Registered = true;
+        CacheCheck<float[]?>.Registered = true;
+        CacheCheck<double[]?>.Registered = true;
+        CacheCheck<decimal[]?>.Registered = true;
+        CacheCheck<DateTimeOffset[]?>.Registered = true;
+        CacheCheck<DateTime[]?>.Registered = true;
+        CacheCheck<DateOnly[]?>.Registered = true;
+        CacheCheck<TimeOnly[]?>.Registered = true;
+        CacheCheck<char[]?>.Registered = true;
+        CacheCheck<string[]?>.Registered = true;
+
+        CacheCheck<List<bool>?>.Registered = true;
+        CacheCheck<List<byte>?>.Registered = true;
+        CacheCheck<List<sbyte>?>.Registered = true;
+        CacheCheck<List<short>?>.Registered = true;
+        CacheCheck<List<ushort>?>.Registered = true;
+        CacheCheck<List<int>?>.Registered = true;
+        CacheCheck<List<uint>?>.Registered = true;
+        CacheCheck<List<long>?>.Registered = true;
+        CacheCheck<List<ulong>?>.Registered = true;
+        CacheCheck<List<float>?>.Registered = true;
+        CacheCheck<List<double>?>.Registered = true;
+        CacheCheck<List<decimal>?>.Registered = true;
+        CacheCheck<List<DateTimeOffset>?>.Registered = true;
+        CacheCheck<List<DateTime>?>.Registered = true;
+        CacheCheck<List<DateOnly>?>.Registered = true;
+        CacheCheck<List<TimeOnly>?>.Registered = true;
+        CacheCheck<List<char>?>.Registered = true;
+        CacheCheck<List<string>?>.Registered = true;
+
+        CacheCheck<Hashtable>.Registered = true;
+        CacheCheck<ArrayList?>.Registered = true;
+
+        CacheCheck<IDictionary<string, object?>>.Registered = true;
+        CacheCheck<IDictionary<object, object?>>.Registered = true;
     }
 
-    public static readonly BuildinFormatterResolver Instance = new BuildinFormatterResolver();
+    internal static readonly BuiltinFormatterResolver Instance = new BuiltinFormatterResolver();
 
     public ITomlValueFormatter<T>? GetFormatter<T>()
     {
         var formatter = DefaultFormatterCache<T>.Formatter;
         if (formatter != null)
             return formatter;
-
-        if (typeof(T).IsArray)
-        {
-            var arrayFormatter = ArrayFormatterCache<T>.Formatter;
-            if (arrayFormatter != null)
-                return arrayFormatter;
-        }
-
-        if (typeof(T).IsGenericType)
-        {
-            var genericFormatter = GeneratedFormatterCache<T>.Formatter;
-            if (genericFormatter != null)
-                return genericFormatter;
-        }
-        
         return null;
     }
-
-    private static object? GetArrayFormatter<T>()
-    {
-        var arrayFormatterType = typeof(ArrayFormatter<>).MakeGenericType(typeof(T).GetElementType()!);
-        return Activator.CreateInstance(arrayFormatterType);
-    }
-
-    private static object? GetGenericTypeFormatter<T>()
-    {
-        var type = typeof(T);
-        var genericTypeDefinition = type.GetGenericTypeDefinition();
-
-        if (formatterTypeTable.TryGetValue(genericTypeDefinition, out var formatterType))
-        {
-            var genericType =  formatterType.MakeGenericType(type.GetGenericArguments());
-            if (genericType != null)
-            {
-                return Activator.CreateInstance(genericType);
-            }
-        }
-        return null;
-    }
-
 }

--- a/src/CsToml/Formatter/Resolver/GeneratedFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/GeneratedFormatterResolver.cs
@@ -1,0 +1,148 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+
+namespace CsToml.Formatter.Resolver;
+
+public sealed class GeneratedFormatterResolver : ITomlValueFormatterResolver
+{
+    internal static readonly GeneratedFormatterResolver Instance = new GeneratedFormatterResolver();
+
+    private sealed class CacheCheck<T>
+    {
+        public static bool Registered;
+    }
+
+    private sealed class GeneratedFormatterCache<T>
+    {
+        public static ITomlValueFormatter<T>? Formatter = default!;
+
+        static GeneratedFormatterCache()
+        {
+            if (CacheCheck<T>.Registered) return;
+
+            if (typeof(T).IsArray)
+            {
+                CacheCheck<T>.Registered = true;
+                Formatter = GetArrayFormatter<T>() as ITomlValueFormatter<T>;
+                return;
+            }
+
+            if (typeof(T).IsGenericType)
+            {
+                CacheCheck<T>.Registered = true;
+                Formatter = GetGenericTypeFormatter<T>() as ITomlValueFormatter<T>;
+                return;
+            }
+        }
+    }
+
+    private static readonly Dictionary<Type, Type> formatterTypeTable = new()
+    {
+        { typeof(Nullable<>), typeof(NullableFormatter<>) },
+        { typeof(Memory<>),  typeof(MemoryFormatter<>) },
+        { typeof(ReadOnlyMemory<>),  typeof(ReadOnlyMemoryFormatter<>) },
+
+        { typeof(List<>), typeof(ListFormatter<>) },
+        { typeof(Stack<>), typeof(StackFormatter<>) },
+        { typeof(HashSet<>), typeof(HashSetFormatter<>) },
+        { typeof(SortedSet<>), typeof(SortedSetFormatter<>) },
+        { typeof(Queue<>), typeof(QueueFormatter<>) },
+        { typeof(LinkedList<>), typeof(LinkedListFormatter<>) },
+        { typeof(SortedList<,>), typeof(SortedListFormatter<,>) },
+        { typeof(ConcurrentQueue<>), typeof(ConcurrentQueueFormatter<>) },
+        { typeof(ConcurrentStack<>), typeof(ConcurrentStackFormatter<>) },
+        { typeof(ConcurrentBag<>), typeof(ConcurrentBagFormatter<>) },
+        { typeof(ReadOnlyCollection<>), typeof(ReadOnlyCollectionFormatter<>) },
+        { typeof(BlockingCollection<>), typeof(BlockingCollectionFormatter<>) },
+        { typeof(PriorityQueue<,>), typeof(PriorityQueueFormatter<,>) },
+        { typeof(Dictionary<,>), typeof(DictionaryFormatter<,>) },
+        { typeof(ReadOnlyDictionary<,>), typeof(ReadOnlyDictionaryFormatter<,>) },
+        { typeof(SortedDictionary<,>), typeof(SortedDictionaryFormatter<,>) },
+        { typeof(ConcurrentDictionary<,>), typeof(ConcurrentDictionaryFormatter<,>) },
+
+        { typeof(ImmutableArray<>), typeof(ImmutableArrayFormatter<>) },
+        { typeof(ImmutableList<>), typeof(ImmutableListFormatter<>) },
+        { typeof(ImmutableStack<>), typeof(ImmutableStackFormatter<>) },
+        { typeof(ImmutableQueue<>), typeof(ImmutableQueueFormatter<>)},
+        { typeof(ImmutableHashSet<>), typeof(ImmutableHashSetFormatter<>) },
+        { typeof(ImmutableSortedSet<>), typeof(ImmutableSortedSetFormatter<>) },
+        { typeof(ImmutableDictionary<,>), typeof(ImmutableDictionaryFormatter<,>) },
+        { typeof(ImmutableSortedDictionary<,>), typeof(ImmutableSortedDictionaryFormatter<,>) },
+
+        { typeof(IEnumerable<>), typeof(IEnumerableFormatter<>) },
+        { typeof(ICollection<>),  typeof(ICollectionFormatter<>) },
+        { typeof(IReadOnlyCollection<>),  typeof(IReadOnlyCollectionFormatter<>) },
+        { typeof(IList<>),  typeof(IListFormatter<>) },
+        { typeof(IReadOnlyList<>),  typeof(IReadOnlyListFormatter<>) },
+        { typeof(ISet<>),  typeof(ISetFormatter<>) },
+        { typeof(IReadOnlySet<>),  typeof(IReadOnlySetFormatter<>) },
+        { typeof(IDictionary<,>),typeof(IDictionaryFormatter<,>) },
+        { typeof(IReadOnlyDictionary<,>),typeof(IReadOnlyDictionaryFormatter<,>) },
+
+        { typeof(KeyValuePair<,>),  typeof(KeyValuePairFormatter<,>) },
+        { typeof(Tuple<>),  typeof(TupleFormatter<>) },
+        { typeof(Tuple<,>),  typeof(TupleFormatter<,>) },
+        { typeof(Tuple<,,>),  typeof(TupleFormatter<,,>) },
+        { typeof(Tuple<,,,>),  typeof(TupleFormatter<,,,>) },
+        { typeof(Tuple<,,,,>),  typeof(TupleFormatter<,,,,>) },
+        { typeof(Tuple<,,,,,>),  typeof(TupleFormatter<,,,,,>) },
+        { typeof(Tuple<,,,,,,>),  typeof(TupleFormatter<,,,,,,>) },
+        { typeof(Tuple<,,,,,,,>),  typeof(TupleFormatter<,,,,,,,>) },
+        { typeof(ValueTuple<>),  typeof(ValueTupleFormatter<>) },
+        { typeof(ValueTuple<,>),  typeof(ValueTupleFormatter<,>) },
+        { typeof(ValueTuple<,,>),  typeof(ValueTupleFormatter<,,>) },
+        { typeof(ValueTuple<,,,>),  typeof(ValueTupleFormatter<,,,>) },
+        { typeof(ValueTuple<,,,,>),  typeof(ValueTupleFormatter<,,,,>) },
+        { typeof(ValueTuple<,,,,,>),  typeof(ValueTupleFormatter<,,,,,>) },
+        { typeof(ValueTuple<,,,,,,>),  typeof(ValueTupleFormatter<,,,,,,>) },
+        { typeof(ValueTuple<,,,,,,,>),  typeof(ValueTupleFormatter<,,,,,,,>) },
+
+#if NET9_0_OR_GREATER
+        { typeof(OrderedDictionary<,>), typeof(OrderedDictionaryFormatter<,>) },
+        { typeof(ReadOnlySet<>), typeof(ReadOnlySetFormatter<>) },
+#endif
+    };
+
+    public ITomlValueFormatter<T>? GetFormatter<T>()
+    {
+        var genericFormatter = GeneratedFormatterCache<T>.Formatter;
+        if (genericFormatter != null)
+            return genericFormatter;
+
+        return null;
+    }
+
+    private static object? GetArrayFormatter<T>()
+    {
+        var arrayFormatterType = typeof(ArrayFormatter<>).MakeGenericType(typeof(T).GetElementType()!);
+        return Activator.CreateInstance(arrayFormatterType);
+    }
+
+    private static object? GetGenericTypeFormatter<T>()
+    {
+        var type = typeof(T);
+        var genericTypeDefinition = type.GetGenericTypeDefinition();
+
+        if (formatterTypeTable.TryGetValue(genericTypeDefinition, out var formatterType))
+        {
+            var genericType = formatterType.MakeGenericType(type.GetGenericArguments());
+            if (genericType != null)
+            {
+                return Activator.CreateInstance(genericType);
+            }
+        }
+        return null;
+    }
+
+    public static bool IsRegistered<T>()
+        => CacheCheck<T>.Registered;
+
+    public static void Register<T>(ITomlValueFormatter<T> fomatter)
+    {
+        if (CacheCheck<T>.Registered) return;
+
+        CacheCheck<T>.Registered = true;
+        GeneratedFormatterCache<T>.Formatter = fomatter;
+    }
+}

--- a/src/CsToml/Formatter/Resolver/GeneratedFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/GeneratedFormatterResolver.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
 
 namespace CsToml.Formatter.Resolver;
 
@@ -135,12 +136,18 @@ public sealed class GeneratedFormatterResolver : ITomlValueFormatterResolver
         return null;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsRegistered<T>()
-        => CacheCheck<T>.Registered;
+    {
+        // If the static constructor in BuiltinFormatterResolver is not called, call it here.
+        if (BuiltinFormatterResolver.Instance.IsRegistered<T>()) return true;
+        return CacheCheck<T>.Registered;
+    }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Register<T>(ITomlValueFormatter<T> fomatter)
     {
-        if (CacheCheck<T>.Registered) return;
+        if (IsRegistered<T>()) return;
 
         CacheCheck<T>.Registered = true;
         GeneratedFormatterCache<T>.Formatter = fomatter;

--- a/src/CsToml/Formatter/Resolver/TomlSerializedObjectFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/TomlSerializedObjectFormatterResolver.cs
@@ -5,9 +5,13 @@ namespace CsToml.Formatter.Resolver;
 
 public sealed class TomlSerializedObjectFormatterResolver : ITomlValueFormatterResolver
 {
-    private sealed class Cache<T>
+    private sealed class CacheCheck<T>
     {
         public static bool Registered;
+    }
+
+    private sealed class Cache<T>
+    {
         public static ITomlValueFormatter<T>? Formatter;
 
         static Cache()
@@ -35,9 +39,9 @@ public sealed class TomlSerializedObjectFormatterResolver : ITomlValueFormatterR
     public static void Register<T>(TomlSerializedObjectFormatter<T> fomatter)
         where T : ITomlSerializedObject<T>
     {
-        if (Cache<T>.Registered) return;
+        if (CacheCheck<T>.Registered) return;
 
-        Cache<T>.Registered = true;
+        CacheCheck<T>.Registered = true;
         Cache<T>.Formatter = fomatter;
     }
 }

--- a/src/CsToml/Formatter/Resolver/TomlSerializedObjectFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/TomlSerializedObjectFormatterResolver.cs
@@ -1,5 +1,6 @@
 ﻿using CsToml.Error;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace CsToml.Formatter.Resolver;
 
@@ -35,6 +36,10 @@ public sealed class TomlSerializedObjectFormatterResolver : ITomlValueFormatterR
     {
         return Cache<T>.Formatter;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsRegistered<T>()
+        => CacheCheck<T>.Registered;
 
     public static void Register<T>(TomlSerializedObjectFormatter<T> fomatter)
         where T : ITomlSerializedObject<T>

--- a/src/CsToml/Formatter/Resolver/TomlValueFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/TomlValueFormatterResolver.cs
@@ -29,10 +29,17 @@ internal sealed class TomlValueFormatterResolver : ITomlValueFormatterResolver
             }
             else
             {
-                var formatter = BuildinFormatterResolver.Instance.GetFormatter<T>();
+                var formatter = BuiltinFormatterResolver.Instance.GetFormatter<T>();
                 if (formatter != null)
                 {
                     Formatter = formatter;
+                    return;
+                }
+
+                var generalizedFormatter = GeneratedFormatterResolver.Instance.GetFormatter<T>();
+                if (generalizedFormatter != null)
+                {
+                    Formatter = generalizedFormatter;
                     return;
                 }
 

--- a/src/CsToml/Formatter/SortedDictionaryFormatter.cs
+++ b/src/CsToml/Formatter/SortedDictionaryFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class SortedDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, SortedDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
+public sealed class SortedDictionaryFormatter<TKey, TValue> : DictionaryBaseFormatter<TKey, TValue, SortedDictionary<TKey, TValue>, Dictionary<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(Dictionary<TKey, TValue> mediator, TKey key, TValue value)

--- a/src/CsToml/Formatter/SortedListFormatter.cs
+++ b/src/CsToml/Formatter/SortedListFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class SortedListFormatter<TKey, TValue> : CollectionBaseFormatter<SortedList<TKey, TValue>, KeyValuePair<TKey, TValue>, SortedList<TKey, TValue>>
+public sealed class SortedListFormatter<TKey, TValue> : CollectionBaseFormatter<SortedList<TKey, TValue>, KeyValuePair<TKey, TValue>, SortedList<TKey, TValue>>
     where TKey : notnull
 {
     protected override void AddValue(SortedList<TKey, TValue> mediator, KeyValuePair<TKey, TValue> element)

--- a/src/CsToml/Formatter/SortedSetFormatter.cs
+++ b/src/CsToml/Formatter/SortedSetFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class SortedSetFormatter<T> : CollectionBaseFormatter<SortedSet<T>, T, SortedSet<T>>
+public sealed class SortedSetFormatter<T> : CollectionBaseFormatter<SortedSet<T>, T, SortedSet<T>>
 {
     protected override void AddValue(SortedSet<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/StackFormatter.cs
+++ b/src/CsToml/Formatter/StackFormatter.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CsToml.Formatter;
 
-internal sealed class StackFormatter<T> : CollectionBaseFormatter<Stack<T>, T, List<T>>
+public sealed class StackFormatter<T> : CollectionBaseFormatter<Stack<T>, T, List<T>>
 {
     protected override void AddValue(List<T> mediator, T element)
     {

--- a/src/CsToml/Formatter/TupleFormatter.cs
+++ b/src/CsToml/Formatter/TupleFormatter.cs
@@ -1,10 +1,9 @@
 ﻿using CsToml.Error;
-using CsToml.Formatter.Resolver;
 using System.Buffers;
 
 namespace CsToml.Formatter;
 
-internal sealed class TupleFormatter<T1> : ITomlValueFormatter<Tuple<T1>?>
+public sealed class TupleFormatter<T1> : ITomlValueFormatter<Tuple<T1>?>
 {
     public Tuple<T1>? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -38,7 +37,7 @@ internal sealed class TupleFormatter<T1> : ITomlValueFormatter<Tuple<T1>?>
     }
 }
 
-internal sealed class TupleFormatter<T1, T2> : ITomlValueFormatter<Tuple<T1, T2>?>
+public sealed class TupleFormatter<T1, T2> : ITomlValueFormatter<Tuple<T1, T2>?>
 {
     public Tuple<T1, T2>? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -86,7 +85,7 @@ internal sealed class TupleFormatter<T1, T2> : ITomlValueFormatter<Tuple<T1, T2>
     }
 }
 
-internal sealed class TupleFormatter<T1, T2, T3> : ITomlValueFormatter<Tuple<T1, T2, T3>?>
+public sealed class TupleFormatter<T1, T2, T3> : ITomlValueFormatter<Tuple<T1, T2, T3>?>
 {
     public Tuple<T1, T2, T3>? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -140,7 +139,7 @@ internal sealed class TupleFormatter<T1, T2, T3> : ITomlValueFormatter<Tuple<T1,
     }
 }
 
-internal sealed class TupleFormatter<T1, T2, T3, T4> : ITomlValueFormatter<Tuple<T1, T2, T3, T4>?>
+public sealed class TupleFormatter<T1, T2, T3, T4> : ITomlValueFormatter<Tuple<T1, T2, T3, T4>?>
 {
     public Tuple<T1, T2, T3, T4>? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -199,7 +198,7 @@ internal sealed class TupleFormatter<T1, T2, T3, T4> : ITomlValueFormatter<Tuple
     }
 }
 
-internal sealed class TupleFormatter<T1, T2, T3, T4, T5> : ITomlValueFormatter<Tuple<T1, T2, T3, T4, T5>?>
+public sealed class TupleFormatter<T1, T2, T3, T4, T5> : ITomlValueFormatter<Tuple<T1, T2, T3, T4, T5>?>
 {
     public Tuple<T1, T2, T3, T4, T5>? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -262,7 +261,7 @@ internal sealed class TupleFormatter<T1, T2, T3, T4, T5> : ITomlValueFormatter<T
     }
 }
 
-internal sealed class TupleFormatter<T1, T2, T3, T4, T5, T6> : ITomlValueFormatter<Tuple<T1, T2, T3, T4, T5, T6>?>
+public sealed class TupleFormatter<T1, T2, T3, T4, T5, T6> : ITomlValueFormatter<Tuple<T1, T2, T3, T4, T5, T6>?>
 {
     public Tuple<T1, T2, T3, T4, T5, T6>? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -330,7 +329,7 @@ internal sealed class TupleFormatter<T1, T2, T3, T4, T5, T6> : ITomlValueFormatt
     }
 }
 
-internal sealed class TupleFormatter<T1, T2, T3, T4, T5, T6, T7> : ITomlValueFormatter<Tuple<T1, T2, T3, T4, T5, T6, T7>?>
+public sealed class TupleFormatter<T1, T2, T3, T4, T5, T6, T7> : ITomlValueFormatter<Tuple<T1, T2, T3, T4, T5, T6, T7>?>
 {
     public Tuple<T1, T2, T3, T4, T5, T6, T7>? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -403,7 +402,7 @@ internal sealed class TupleFormatter<T1, T2, T3, T4, T5, T6, T7> : ITomlValueFor
     }
 }
 
-internal sealed class TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest> : ITomlValueFormatter<Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>?>
+public sealed class TupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest> : ITomlValueFormatter<Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>?>
     where TRest : notnull
 {
     public Tuple<T1, T2, T3, T4, T5, T6, T7, TRest>? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)

--- a/src/CsToml/Formatter/TypeFormatter.cs
+++ b/src/CsToml/Formatter/TypeFormatter.cs
@@ -1,10 +1,9 @@
 ﻿using CsToml.Error;
 using System.Buffers;
-using System.Text;
 
 namespace CsToml.Formatter;
 
-internal sealed class TypeFormatter : ITomlValueFormatter<Type?>
+public sealed class TypeFormatter : ITomlValueFormatter<Type?>
 {
     public static readonly TypeFormatter Instance = new TypeFormatter();
 

--- a/src/CsToml/Formatter/ValueTupleFormatter.cs
+++ b/src/CsToml/Formatter/ValueTupleFormatter.cs
@@ -1,10 +1,9 @@
 ﻿using CsToml.Error;
-using CsToml.Formatter.Resolver;
 using System.Buffers;
 
 namespace CsToml.Formatter;
 
-internal sealed class ValueTupleFormatter<T1> : ITomlValueFormatter<ValueTuple<T1>>
+public sealed class ValueTupleFormatter<T1> : ITomlValueFormatter<ValueTuple<T1>>
 {
     public ValueTuple<T1> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -32,7 +31,7 @@ internal sealed class ValueTupleFormatter<T1> : ITomlValueFormatter<ValueTuple<T
     }
 }
 
-internal sealed class ValueTupleFormatter<T1, T2> : ITomlValueFormatter<ValueTuple<T1, T2>>
+public sealed class ValueTupleFormatter<T1, T2> : ITomlValueFormatter<ValueTuple<T1, T2>>
 {
     public ValueTuple<T1, T2> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -74,7 +73,7 @@ internal sealed class ValueTupleFormatter<T1, T2> : ITomlValueFormatter<ValueTup
     }
 }
 
-internal sealed class ValueTupleFormatter<T1, T2, T3> : ITomlValueFormatter<ValueTuple<T1, T2, T3>>
+public sealed class ValueTupleFormatter<T1, T2, T3> : ITomlValueFormatter<ValueTuple<T1, T2, T3>>
 {
     public ValueTuple<T1, T2, T3> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -122,7 +121,7 @@ internal sealed class ValueTupleFormatter<T1, T2, T3> : ITomlValueFormatter<Valu
     }
 }
 
-internal sealed class ValueTupleFormatter<T1, T2, T3, T4> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4>>
+public sealed class ValueTupleFormatter<T1, T2, T3, T4> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4>>
 {
     public ValueTuple<T1, T2, T3, T4> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -175,7 +174,7 @@ internal sealed class ValueTupleFormatter<T1, T2, T3, T4> : ITomlValueFormatter<
     }
 }
 
-internal sealed class ValueTupleFormatter<T1, T2, T3, T4, T5> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4, T5>>
+public sealed class ValueTupleFormatter<T1, T2, T3, T4, T5> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4, T5>>
 {
     public ValueTuple<T1, T2, T3, T4, T5> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -232,7 +231,7 @@ internal sealed class ValueTupleFormatter<T1, T2, T3, T4, T5> : ITomlValueFormat
     }
 }
 
-internal sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4, T5, T6>>
+public sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4, T5, T6>>
 {
     public ValueTuple<T1, T2, T3, T4, T5, T6> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -294,7 +293,7 @@ internal sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6> : ITomlValueFo
     }
 }
 
-internal sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>
+public sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>
 {
     public ValueTuple<T1, T2, T3, T4, T5, T6, T7> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
@@ -361,7 +360,7 @@ internal sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7> : ITomlVal
     }
 }
 
-internal sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>
+public sealed class ValueTupleFormatter<T1, T2, T3, T4, T5, T6, T7, TRest> : ITomlValueFormatter<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>
     where TRest : struct
 {
     public ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)

--- a/tests/CsToml.Generator.Tests/Seirialization/SerializationTest.cs
+++ b/tests/CsToml.Generator.Tests/Seirialization/SerializationTest.cs
@@ -625,8 +625,8 @@ public class TomlPrimitiveTest
             writer.AppendLine("Long = 123");
             writer.AppendLine("Float = 123.456");
             writer.AppendLine("Boolean = true");
-            writer.AppendLine("LocalDateTime = 1979-05-27T07:32:00");
             writer.AppendLine("OffsetDateTime = 1979-05-27T07:32:00Z");
+            writer.AppendLine("LocalDateTime = 1979-05-27T07:32:00");
             writer.AppendLine("LocalDate = 1979-05-27");
             writer.AppendLine("LocalTime = 07:32:30");
             writer.Flush();
@@ -642,8 +642,8 @@ public class TomlPrimitiveTest
             writer.AppendLine("Long = 123");
             writer.AppendLine("Float = 123.456");
             writer.AppendLine("Boolean = true");
-            writer.AppendLine("LocalDateTime = 1979-05-27T07:32:00");
             writer.AppendLine("OffsetDateTime = 1979-05-27T07:32:00Z");
+            writer.AppendLine("LocalDateTime = 1979-05-27T07:32:00");
             writer.AppendLine("LocalDate = 1979-05-27");
             writer.AppendLine("LocalTime = 07:32:30");
             writer.Flush();

--- a/tests/CsToml.Generator.Tests/TypeDeclarations.cs
+++ b/tests/CsToml.Generator.Tests/TypeDeclarations.cs
@@ -677,6 +677,13 @@ internal partial class TypeImmutable
     public ImmutableSortedDictionary<string, object?> ImmutableSortedDictionary { get; set; }
 }
 
+[TomlSerializedObject]
+public partial class TypeMemory
+{
+    [TomlValueOnSerialized]
+    public Memory<byte> Memory { get; set; }
+}
+
 #if NET9_0_OR_GREATER
 
 [TomlSerializedObject]


### PR DESCRIPTION
This PR fixes a runtime error bug in the Deserialize<T>/Serialize<T> AOT build.

* It add `[DynamicallyAccessedMembers]` to the type parameter of `CsTomlSerializer.Deserialize/Serialize`.
* Fix the generator that generates the source for `ITomlSerializedObjectRegister.Register`.
* Each `ITomlValueFormatterResolver` functionality added (Formatter registration method)

## Related issues
#22
