### PR TITLE
Generator Fixes and Add Feature

### DIFF
--- a/sandbox/ConsoleNativeAOT/Type.cs
+++ b/sandbox/ConsoleNativeAOT/Type.cs
@@ -1,0 +1,14 @@
+﻿
+namespace ConsoleNativeAOT;
+
+public enum Color
+{
+    Red,
+    Green,
+    Blue
+}
+
+public partial struct TestStruct2
+{
+    public long Value { get; set; }
+}

--- a/src/CsToml/CsTomlReader.cs
+++ b/src/CsToml/CsTomlReader.cs
@@ -1431,7 +1431,7 @@ internal ref struct CsTomlReader
 
     private bool ExistNoNewLineAndComment(int length)
     {
-        if (sequenceReader.Length <= sequenceReader.Consumed + length)
+        if (sequenceReader.Length < sequenceReader.Consumed + length)
             return false;
 
         var index = 0;

--- a/src/CsToml/Formatter/Resolver/GeneratedFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/GeneratedFormatterResolver.cs
@@ -22,6 +22,13 @@ public sealed class GeneratedFormatterResolver : ITomlValueFormatterResolver
         {
             if (CacheCheck<T>.Registered) return;
 
+            if (typeof(T).IsEnum)
+            {
+                CacheCheck<T>.Registered = true;
+                Formatter = GetEnumFormatter<T>() as ITomlValueFormatter<T>;
+                return;
+            }
+
             if (typeof(T).IsArray)
             {
                 CacheCheck<T>.Registered = true;
@@ -112,6 +119,12 @@ public sealed class GeneratedFormatterResolver : ITomlValueFormatterResolver
             return genericFormatter;
 
         return null;
+    }
+
+    private static object? GetEnumFormatter<T>()
+    {
+        var enumFormatterType = typeof(EnumFormatter<>).MakeGenericType(typeof(T));
+        return Activator.CreateInstance(enumFormatterType);
     }
 
     private static object? GetArrayFormatter<T>()

--- a/src/CsToml/Formatter/Resolver/TomlValueFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/TomlValueFormatterResolver.cs
@@ -21,12 +21,6 @@ internal sealed class TomlValueFormatterResolver : ITomlValueFormatterResolver
                 Formatter = PrimitiveObjectFormatterResolver.Instance.GetFormatter<T>();
                 return;
             }
-            else if (typeof(T).IsEnum)
-            {
-                var enumFormatterType = typeof(EnumFormatter<>).MakeGenericType(typeof(T));
-                Formatter = Activator.CreateInstance(enumFormatterType) as ITomlValueFormatter<T>;
-                return;
-            }
             else
             {
                 var formatter = BuiltinFormatterResolver.Instance.GetFormatter<T>();

--- a/src/CsToml/TomlDocumentNode.cs
+++ b/src/CsToml/TomlDocumentNode.cs
@@ -7,6 +7,7 @@ using CsToml.Values.Internal;
 using System.Buffers;
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -29,9 +30,13 @@ public struct TomlDocumentNode
 
     public readonly bool HasValue => Value.HasValue || NodeCount > 0;
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly bool HasNodeOnly => !Value.HasValue && NodeCount > 0;
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly bool HasValueOnly => Value.HasValue && NodeCount == 0;
+
+    public readonly TomlValueType ValueType => Value.Type;
 
     public TomlDocumentNode this[ReadOnlySpan<char> key]
     {

--- a/src/CsToml/Values/TomlArray.cs
+++ b/src/CsToml/Values/TomlArray.cs
@@ -19,6 +19,8 @@ internal sealed partial class TomlArray(int capacity) : TomlValue, IEnumerable<T
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.Array;
+
     public TomlValue LastValue => Count > 0 ? values[Count - 1] : Empty;
 
     public TomlValue this[int index] => values[index];

--- a/src/CsToml/Values/TomlBoolean.GetValue.cs
+++ b/src/CsToml/Values/TomlBoolean.GetValue.cs
@@ -4,7 +4,7 @@ namespace CsToml.Values;
 internal partial class TomlBoolean
 {
     public override bool CanGetValue(TomlValueFeature feature) 
-        => ((TomlValueFeature.String | TomlValueFeature.Int64 |  TomlValueFeature.Double | TomlValueFeature.Bool | TomlValueFeature.Number | TomlValueFeature.Object) & feature) == feature;
+        => ((TomlValueFeature.String | TomlValueFeature.Int64 |  TomlValueFeature.Double | TomlValueFeature.Boolean | TomlValueFeature.Number | TomlValueFeature.Object) & feature) == feature;
 
     public override string GetString() => Value ? bool.TrueString : bool.FalseString;
 

--- a/src/CsToml/Values/TomlBoolean.cs
+++ b/src/CsToml/Values/TomlBoolean.cs
@@ -1,6 +1,4 @@
 ﻿using CsToml.Error;
-using CsToml.Extension;
-using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -16,6 +14,8 @@ internal sealed partial class TomlBoolean : TomlValue
     public bool Value { get; init; }
 
     public override bool HasValue => true;
+
+    public override TomlValueType Type => TomlValueType.Boolean;
 
     private TomlBoolean(bool value)
     {

--- a/src/CsToml/Values/TomlDottedKey.GetValue.cs
+++ b/src/CsToml/Values/TomlDottedKey.GetValue.cs
@@ -9,7 +9,7 @@ internal partial class TomlDottedKey
         TomlValueFeature.String | 
         TomlValueFeature.Int64 | 
         TomlValueFeature.Double | 
-        TomlValueFeature.Bool |
+        TomlValueFeature.Boolean |
         TomlValueFeature.DateTime | 
         TomlValueFeature.DateTimeOffset | 
         TomlValueFeature.DateOnly | 

--- a/src/CsToml/Values/TomlDottedKey.cs
+++ b/src/CsToml/Values/TomlDottedKey.cs
@@ -48,6 +48,8 @@ internal abstract partial class TomlDottedKey(ReadOnlySpan<byte> value) :
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.Key;
+
     [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
     public ReadOnlySpan<byte> Value => bytes.AsSpan();
 

--- a/src/CsToml/Values/TomlFloat.GetValue.cs
+++ b/src/CsToml/Values/TomlFloat.GetValue.cs
@@ -4,7 +4,7 @@ namespace CsToml.Values;
 internal partial class TomlFloat
 {
     public override bool CanGetValue(TomlValueFeature feature)
-        => ((TomlValueFeature.String | TomlValueFeature.Int64 | TomlValueFeature.Double | TomlValueFeature.Bool | TomlValueFeature.Number | TomlValueFeature.Object) & feature) == feature;
+        => ((TomlValueFeature.String | TomlValueFeature.Int64 | TomlValueFeature.Double | TomlValueFeature.Boolean | TomlValueFeature.Number | TomlValueFeature.Object) & feature) == feature;
 
     public override string GetString() => ToString();
 

--- a/src/CsToml/Values/TomlFloat.cs
+++ b/src/CsToml/Values/TomlFloat.cs
@@ -25,6 +25,8 @@ internal sealed partial class TomlFloat(double value, TomlFloat.FloatKind kind =
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.Float;
+
     internal FloatKind Kind { get; } = kind;
 
     internal override void ToTomlString<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer)

--- a/src/CsToml/Values/TomlInlineTable.cs
+++ b/src/CsToml/Values/TomlInlineTable.cs
@@ -14,6 +14,8 @@ internal sealed partial class TomlInlineTable : TomlValue
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.Integer;
+
     [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
     internal TomlTableNode RootNode => inlineTable.RootNode;
 

--- a/src/CsToml/Values/TomlInteger.GetValue.cs
+++ b/src/CsToml/Values/TomlInteger.GetValue.cs
@@ -4,7 +4,7 @@ namespace CsToml.Values;
 internal partial class TomlInteger
 {
     public override bool CanGetValue(TomlValueFeature feature)
-        => ((TomlValueFeature.String | TomlValueFeature.Int64 | TomlValueFeature.Double | TomlValueFeature.Bool | TomlValueFeature.Number | TomlValueFeature.Object) & feature) == feature;
+        => ((TomlValueFeature.String | TomlValueFeature.Int64 | TomlValueFeature.Double | TomlValueFeature.Boolean | TomlValueFeature.Number | TomlValueFeature.Object) & feature) == feature;
 
     public override string GetString() => ToString();
 

--- a/src/CsToml/Values/TomlInteger.cs
+++ b/src/CsToml/Values/TomlInteger.cs
@@ -39,6 +39,8 @@ internal sealed partial class TomlInteger : TomlValue
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.Integer;
+
     private TomlInteger(long value)
     {
         this.Value = value;

--- a/src/CsToml/Values/TomlLocalDate.cs
+++ b/src/CsToml/Values/TomlLocalDate.cs
@@ -1,7 +1,5 @@
 ﻿using CsToml.Error;
-using System;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace CsToml.Values;
 
@@ -11,6 +9,8 @@ internal sealed partial class TomlLocalDate(DateOnly value) : TomlValue
     public DateOnly Value { get; private set; } = value;
 
     public override bool HasValue => true;
+
+    public override TomlValueType Type => TomlValueType.LocalDate;
 
     internal override void ToTomlString<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer)
     {

--- a/src/CsToml/Values/TomlLocalDateTime.cs
+++ b/src/CsToml/Values/TomlLocalDateTime.cs
@@ -10,6 +10,8 @@ internal sealed partial class TomlLocalDateTime(DateTime value) : TomlValue
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.LocalDateTime;
+
     internal override void ToTomlString<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer)
     {
         writer.WriteDateTime(Value);

--- a/src/CsToml/Values/TomlLocalTime.cs
+++ b/src/CsToml/Values/TomlLocalTime.cs
@@ -10,6 +10,8 @@ internal sealed partial class TomlLocalTime(TimeOnly value) : TomlValue
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.LocalTime;
+
     internal override void ToTomlString<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer)
     {
         writer.WriteTimeOnly(Value);

--- a/src/CsToml/Values/TomlOffsetDateTime.cs
+++ b/src/CsToml/Values/TomlOffsetDateTime.cs
@@ -10,6 +10,8 @@ internal sealed partial class TomlOffsetDateTime(DateTimeOffset value) : TomlVal
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.OffsetDateTime;
+
     internal override void ToTomlString<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer)
     {
         writer.WriteDateTimeOffset(Value);

--- a/src/CsToml/Values/TomlString.GetValue.cs
+++ b/src/CsToml/Values/TomlString.GetValue.cs
@@ -6,7 +6,7 @@ namespace CsToml.Values;
 internal partial class TomlString
 {
     public override bool CanGetValue(TomlValueFeature feature)
-        => ((TomlValueFeature.String | TomlValueFeature.Int64 | TomlValueFeature.Double | TomlValueFeature.Bool | 
+        => ((TomlValueFeature.String | TomlValueFeature.Int64 | TomlValueFeature.Double | TomlValueFeature.Boolean | 
             TomlValueFeature.DateTime | TomlValueFeature.DateTimeOffset | TomlValueFeature.DateOnly | TomlValueFeature.TimeOnly | TomlValueFeature.Object) & feature) == feature;
 
     public override string GetString() => Utf16String;

--- a/src/CsToml/Values/TomlString.cs
+++ b/src/CsToml/Values/TomlString.cs
@@ -225,6 +225,8 @@ internal abstract partial class TomlString(string value) : TomlValue, ITomlStrin
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.String;
+
     [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
     public string Utf16String => value;
 

--- a/src/CsToml/Values/TomlTable.cs
+++ b/src/CsToml/Values/TomlTable.cs
@@ -15,6 +15,8 @@ internal sealed partial class TomlTable : TomlValue
 
     public override bool HasValue => true;
 
+    public override TomlValueType Type => TomlValueType.Table;
+
     [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
     internal TomlTableNode RootNode => node;
 

--- a/src/CsToml/Values/TomlValue.GetValue.cs
+++ b/src/CsToml/Values/TomlValue.GetValue.cs
@@ -148,7 +148,7 @@ public partial class TomlValue
 
     public bool TryGetBool(out bool value)
     {
-        if (CanGetValue(TomlValueFeature.Bool))
+        if (CanGetValue(TomlValueFeature.Boolean))
         {
             try
             {

--- a/src/CsToml/Values/TomlValue.cs
+++ b/src/CsToml/Values/TomlValue.cs
@@ -12,6 +12,8 @@ public abstract partial class TomlValue :
 
     public virtual bool HasValue => false;
 
+    public abstract TomlValueType Type { get; }
+
     internal virtual void ToTomlString<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer) // Write TOML format.
         where TBufferWriter : IBufferWriter<byte>
     {
@@ -41,6 +43,8 @@ public abstract partial class TomlValue :
     private sealed class CsTomlEmpty : TomlValue
     {
         internal static readonly string DisplayValue = "Empty value";
+
+        public override TomlValueType Type => TomlValueType.Empty;
 
         public CsTomlEmpty() : base() { }
 

--- a/src/CsToml/Values/TomlValueFeature.cs
+++ b/src/CsToml/Values/TomlValueFeature.cs
@@ -8,7 +8,7 @@ public enum TomlValueFeature
     String = 1,
     Int64 = 1 << 1,
     Double = 1 << 2,
-    Bool = 1 << 3,
+    Boolean = 1 << 3,
     Number = 1 << 4,
     DateTime = 1 << 5,
     DateTimeOffset = 1 << 6,
@@ -18,4 +18,21 @@ public enum TomlValueFeature
     Array = 1 << 10,
     Table = 1 << 11,
     InlineTable = 1 << 12,
+}
+
+public enum TomlValueType
+{
+    Key = -1, // This is for internal use only.
+    Empty = 0, // Rarely used.
+    String = 1,
+    Integer = 2,
+    Float = 3,
+    Boolean = 4,
+    OffsetDateTime = 5,
+    LocalDateTime = 6,
+    LocalDate = 7,
+    LocalTime = 8,
+    Array = 9,
+    Table = 10, // Rarely used.
+    InlineTable = 11, // Rarely used.
 }

--- a/tests/CsToml.Generator.Tests/TypeDeclarations2.cs
+++ b/tests/CsToml.Generator.Tests/TypeDeclarations2.cs
@@ -1,0 +1,34 @@
+﻿using CsToml.Generator.Tests;
+
+namespace CsToml.Generator.Other; // Separate namespace for verification.
+
+[TomlSerializedObject]
+internal partial struct TestStruct
+{
+    [TomlValueOnSerialized]
+    public int Value { get; set; }
+
+    [TomlValueOnSerialized]
+    public string Str { get; set; }
+}
+
+
+[TomlSerializedObject]
+internal partial class TypeTable3
+{
+    [TomlValueOnSerialized]
+    public string Value { get; set; }
+}
+
+[TomlSerializedObject]
+internal partial class TypeTableB
+{
+    [TomlValueOnSerialized]
+    public TypeTableC TableC { get; set; }
+
+    [TomlValueOnSerialized]
+    public string Value { get; set; }
+
+    [TomlValueOnSerialized]
+    public List<TypeTableE> TableECollection { get; set; }
+}

--- a/tests/CsToml.Tests/DefaultTest.cs
+++ b/tests/CsToml.Tests/DefaultTest.cs
@@ -1,5 +1,6 @@
 ﻿
 using CsToml.Error;
+using CsToml.Values;
 using System.Text;
 using Utf8StringInterpolation;
 
@@ -243,6 +244,13 @@ trimmed in raw strings.
 
         //buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
     }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"key = ""value"""u8);
+        (document!.RootNode["key"].ValueType == TomlValueType.String).ShouldBeTrue();
+    }
 }
 
 public class TomlIntegerTest
@@ -293,6 +301,13 @@ bin1 = 0b11010110
 
         buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
     }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"int1 = +99"u8);
+        (document!.RootNode["int1"].ValueType == TomlValueType.Integer).ShouldBeTrue();
+    }
 }
 
 public class TomlFloatTest
@@ -339,6 +354,13 @@ sf6 = -nan
 
         buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
     }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"flt1 = +1.0"u8);
+        (document!.RootNode["flt1"].ValueType == TomlValueType.Float).ShouldBeTrue();
+    }
 }
 
 public class TomlBooleanTest
@@ -360,6 +382,13 @@ bool2 = false
         writer.Flush();
 
         buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
+    }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"bool1 = true"u8);
+        (document!.RootNode["bool1"].ValueType == TomlValueType.Boolean).ShouldBeTrue();
     }
 }
 
@@ -469,6 +498,13 @@ odt45 = 1979-05-27T00:32:00.111111-07:00
 
         buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
     }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"odt1 = 1979-05-27T07:32:00Z"u8);
+        (document!.RootNode["odt1"].ValueType == TomlValueType.OffsetDateTime).ShouldBeTrue();
+    }
 }
 
 public class TomlLocalDateTimeTest
@@ -535,6 +571,13 @@ ldt24 = 1979-05-27T00:32:00.111111
 
         buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
     }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"ldt1 = 1979-05-27T07:32:00"u8);
+        (document!.RootNode["ldt1"].ValueType == TomlValueType.LocalDateTime).ShouldBeTrue();
+    }
 }
 
 public class TomlLocalDateTest
@@ -558,6 +601,13 @@ ld3 = 1979-12-31
         writer.Flush();
 
         buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
+    }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"ld1 = 1979-05-27"u8);
+        (document!.RootNode["ld1"].ValueType == TomlValueType.LocalDate).ShouldBeTrue();
     }
 }
 
@@ -625,6 +675,13 @@ lt24 = 00:32:00.111111
 
         buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
     }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"lt1 = 07:32:00"u8);
+        (document!.RootNode["lt1"].ValueType == TomlValueType.LocalTime).ShouldBeTrue();
+    }
 }
 
 public class TomlArrayTest
@@ -654,6 +711,13 @@ string_array = [""all"", 'strings', """"""are the same"""""", '''type''']
         writer.Flush();
 
         buffer.ToArray().ShouldBe(serializeText.ByteSpan.ToArray());
+    }
+
+    [Fact]
+    public void ValueType()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>("integers = [ 1, 2, 3 ]"u8);
+        (document!.RootNode["integers"].ValueType == TomlValueType.Array).ShouldBeTrue();
     }
 }
 


### PR DESCRIPTION
This PR adds the following fixes and new features,

* [Generator] Adding namespaces for type parameters.
* [Generator] Fix `EnumFormatter<TEnum>` to generate in `ITomlSerializedObjectRegister.Register`.
* Fix `CsTomlReader.ExistNoNewLineAndComment`.
* Adding `TomlDocumentAdd.ValueType` property.