### PR TITLE
Fix the floating point serialization process for special float values.

### DIFF
--- a/src/CsToml/Utf8TomlDocumentWriter.cs
+++ b/src/CsToml/Utf8TomlDocumentWriter.cs
@@ -135,23 +135,37 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
 
     public void WriteDouble(double value)
     {
-        var length = 32;
-        int bytesWritten;
-
-        var writtenSpan = writer.GetSpan(length);
-        while (!value.TryFormat(writtenSpan, out bytesWritten, "G", CultureInfo.InvariantCulture))
+        switch(value)
         {
-            length *= 2;
-            writtenSpan = writer.GetSpan(length);
-        }
-        writer.Advance(bytesWritten);
+            case double.NegativeInfinity:
+                WriteBytes("-inf"u8);
+                return;
+            case double.PositiveInfinity:
+                WriteBytes("inf"u8);
+                return;
+            case double.NaN:
+                WriteBytes("nan"u8);
+                return;
+            default:
+                var length = 32;
+                int bytesWritten;
 
-        // integer check
-        if (!writtenSpan.Slice(0, bytesWritten).ContainsAny(".eE"u8))
-        {
-            var writtenSpanEx = writer.GetWrittenSpan(2);
-            writtenSpanEx[0] = TomlCodes.Symbol.DOT;
-            writtenSpanEx[1] = TomlCodes.Number.Zero;
+                var writtenSpan = writer.GetSpan(length);
+                while (!value.TryFormat(writtenSpan, out bytesWritten, "G", CultureInfo.InvariantCulture))
+                {
+                    length *= 2;
+                    writtenSpan = writer.GetSpan(length);
+                }
+                writer.Advance(bytesWritten);
+
+                // integer check
+                if (!writtenSpan.Slice(0, bytesWritten).ContainsAny(".eE"u8))
+                {
+                    var writtenSpanEx = writer.GetWrittenSpan(2);
+                    writtenSpanEx[0] = TomlCodes.Symbol.DOT;
+                    writtenSpanEx[1] = TomlCodes.Number.Zero;
+                }
+                return;
         }
     }
 

--- a/src/CsToml/Values/TomlFloat.cs
+++ b/src/CsToml/Values/TomlFloat.cs
@@ -5,21 +5,12 @@ using System.Globalization;
 namespace CsToml.Values;
 
 [DebuggerDisplay("{Value}")]
-internal sealed partial class TomlFloat(double value, TomlFloat.FloatKind kind = TomlFloat.FloatKind.Normal) : TomlValue
+internal sealed partial class TomlFloat(double value) : TomlValue
 {
-    public readonly static TomlFloat Inf = new(TomlCodes.Float.Inf, FloatKind.Inf);
-    public readonly static TomlFloat NInf = new (TomlCodes.Float.NInf, FloatKind.NInf);
-    public readonly static TomlFloat Nan = new (TomlCodes.Float.Nan, FloatKind.Nan);
-    public readonly static TomlFloat PNan = new(TomlCodes.Float.Nan, FloatKind.PNan);
-
-    internal enum FloatKind : byte
-    {
-        Normal,
-        Inf,
-        NInf,
-        Nan,
-        PNan
-    }
+    public readonly static TomlFloat Inf = new(TomlCodes.Float.Inf);
+    public readonly static TomlFloat NInf = new (TomlCodes.Float.NInf);
+    public readonly static TomlFloat Nan = new (TomlCodes.Float.Nan);
+    public readonly static TomlFloat PNan = new(TomlCodes.Float.Nan);
 
     public double Value { get; private set; } = value;
 
@@ -27,32 +18,9 @@ internal sealed partial class TomlFloat(double value, TomlFloat.FloatKind kind =
 
     public override TomlValueType Type => TomlValueType.Float;
 
-    internal FloatKind Kind { get; } = kind;
-
     internal override void ToTomlString<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer)
     {
-        if (Kind == FloatKind.Normal)
-        {
-            writer.WriteDouble(Value);
-            return;
-        }
-
-        switch(Kind)
-        {
-            case FloatKind.Inf:
-                writer.WriteBytes("inf"u8);
-                break;
-            case FloatKind.NInf:
-                writer.WriteBytes("-inf"u8);
-                break;
-            case FloatKind.Nan:
-            case FloatKind.PNan:
-                writer.WriteBytes("nan"u8);
-                break;
-            default:
-                return;
-        }
-        return;
+        writer.WriteDouble(Value);
     }
 
     public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)

--- a/tests/CsToml.Generator.Tests/Seirialization/SerializationTest.cs
+++ b/tests/CsToml.Generator.Tests/Seirialization/SerializationTest.cs
@@ -682,6 +682,65 @@ public class TomlPrimitiveTest
     }
 }
 
+public class TypeTomlDoubleTest
+{
+    [Fact]
+    public void Serialize()
+    {
+        var typeTomlDouble = new TypeTomlDouble()
+        {
+            Normal = 123.456,
+            Inf = double.PositiveInfinity,
+            NInf = double.NegativeInfinity,
+            Nan = double.NaN,
+        };
+
+        {
+            using var bytes = CsTomlSerializer.Serialize(typeTomlDouble);
+
+            using var buffer = Utf8String.CreateWriter(out var writer);
+            writer.AppendLine("Normal = 123.456");
+            writer.AppendLine("Inf = inf");
+            writer.AppendLine("NInf = -inf");
+            writer.AppendLine("Nan = nan");
+            writer.Flush();
+
+            var expected = buffer.ToArray();
+            bytes.ByteSpan.ToArray().ShouldBe(expected);
+        }
+        {
+            using var bytes = CsTomlSerializer.Serialize(typeTomlDouble, Option.Header);
+
+            using var buffer = Utf8String.CreateWriter(out var writer);
+            writer.AppendLine("Normal = 123.456");
+            writer.AppendLine("Inf = inf");
+            writer.AppendLine("NInf = -inf");
+            writer.AppendLine("Nan = nan");
+            writer.Flush();
+
+            var expected = buffer.ToArray();
+            bytes.ByteSpan.ToArray().ShouldBe(expected);
+        }
+    }
+
+    [Fact]
+    public void Deserialize()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("Normal = 123.456");
+        writer.AppendLine("Inf = inf");
+        writer.AppendLine("NInf = -inf");
+        writer.AppendLine("Nan = nan");
+        writer.Flush();
+
+        var typeTomlDouble = CsTomlSerializer.Deserialize<TypeTomlDouble>(buffer.WrittenSpan);
+        typeTomlDouble.Normal.ShouldBe(123.456);
+        typeTomlDouble.Inf.ShouldBe(double.PositiveInfinity);
+        typeTomlDouble.NInf.ShouldBe(double.NegativeInfinity);
+        typeTomlDouble.Nan.ShouldBe(double.NaN);
+    }
+}
+
 public class NullableTypeTest
 {
     [Fact]

--- a/tests/CsToml.Generator.Tests/TypeDeclarations.cs
+++ b/tests/CsToml.Generator.Tests/TypeDeclarations.cs
@@ -148,6 +148,22 @@ internal partial class TomlPrimitive
 }
 
 [TomlSerializedObject]
+public partial class TypeTomlDouble
+{
+    [TomlValueOnSerialized]
+    public double Normal { get; set; }
+
+    [TomlValueOnSerialized]
+    public double Inf { get; set; }
+
+    [TomlValueOnSerialized]
+    public double NInf { get; set; }
+
+    [TomlValueOnSerialized]
+    public double Nan { get; set; }
+}
+
+[TomlSerializedObject]
 internal partial class NullableType
 {
     [TomlValueOnSerialized]


### PR DESCRIPTION
This PR fixes the floating point serialization process (Utf8TomlDocumentWriter.WriteDouble) for Special float values (double.PositiveInfinity, double.NegativeInfinity, double.NaN).

## Related issues
#28