### PR TITLE
Upgrade v1.7.2

### DIFF
--- a/src/CsToml/Error/CsTomlException.cs
+++ b/src/CsToml/Error/CsTomlException.cs
@@ -5,7 +5,7 @@ namespace CsToml.Error;
 
 public class CsTomlException : Exception
 {
-    internal CsTomlException(string? message) : base(message)
+    public CsTomlException(string? message) : base(message)
     {}
 
     internal CsTomlException(string? message, Exception? innerException) : base(message, innerException)

--- a/src/CsToml/Utility/ByteBufferSegmentWriter.cs
+++ b/src/CsToml/Utility/ByteBufferSegmentWriter.cs
@@ -47,20 +47,17 @@ internal sealed class ByteBufferSegmentWriter : IBufferWriter<byte>, IDisposable
     private List<ByteBufferSegment> segments;
     private ByteBufferSegment currentSegment;
     private int segmentSize;
-    private long written;
 
     public ByteBufferSegmentWriter()
     {
         segments = new List<ByteBufferSegment>();
         currentSegment = new ByteBufferSegment(DefaultBufferSize);
         segmentSize = DefaultBufferSize;
-        written = 0;
     }
 
     public void Advance(int count)
     {
         currentSegment.Advance(count);
-        written += count;
     }
 
     public Memory<byte> GetMemory(int sizeHint = 0)
@@ -116,7 +113,6 @@ internal sealed class ByteBufferSegmentWriter : IBufferWriter<byte>, IDisposable
         }
         segments.Clear();
         currentSegment.Return();
-        written = 0;
     }
 
     public void WriteTo<TByteWriter>(TByteWriter writer)

--- a/src/NuGet.props
+++ b/src/NuGet.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
     <PropertyGroup>
         <Authors>prozolic</Authors>
         <Description>Microsoft.Extensions.Configuration extensions using CsToml.</Description>
@@ -8,7 +8,7 @@
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <VersionPrefix>1.7.1</VersionPrefix>
+        <VersionPrefix>1.7.2</VersionPrefix>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR upgrades v1.7.2.

- Make `CsTomlException` constructor public (https://github.com/prozolic/CsToml/issues/60)