### PR TITLE
Add nullable reference type support and improve struct/class formatter handling

### DIFF
--- a/src/CsToml.Generator/FormatterTypeMetaData.cs
+++ b/src/CsToml.Generator/FormatterTypeMetaData.cs
@@ -326,6 +326,13 @@ internal static class FormatterTypeMetaData
                     return TomlSerializationKind.TomlSerializedObject;
                 }
 
+                // For a Nullable<T> Collection/Dictionary like ImmutableArray<T>?
+                if (TryGetNullableParameterType(type, out var nullableType) &&
+                    (ContainsCollectionType(nullableType!) || ContainsDictionary(nullableType!)))
+                {
+                    type = nullableType!;
+                }
+
                 var genericFormatterType = TryGetGenericFormatterType(type, out var _);
                 if (genericFormatterType != GenericFormatterType.None)
                 {

--- a/src/CsToml.Generator/TypeMeta.cs
+++ b/src/CsToml.Generator/TypeMeta.cs
@@ -18,6 +18,8 @@ internal sealed class TypeMeta
     public string TypeName { get; }
     public string FullTypeName { get; }
     public string TypeKeyword { get; }
+    public string GenericTypeParameterName { get; }
+    public bool IsReferenceType => !symbol.IsValueType;
 
     public TypeMeta(INamedTypeSymbol symbol, TypeDeclarationSyntax syntax)
     {
@@ -26,8 +28,7 @@ internal sealed class TypeMeta
 
         TypeName = symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
         FullTypeName = symbol.ToFullFormatString();
-
-        Console.WriteLine(FullTypeName);
+        GenericTypeParameterName = symbol.IsValueType ? TypeName : $"{TypeName}?";
 
         if (symbol.IsRecord)
             TypeKeyword = symbol.IsValueType ? "record struct" : "record";

--- a/src/CsToml/Formatter/Resolver/TomlSerializedObjectFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/TomlSerializedObjectFormatterResolver.cs
@@ -44,7 +44,16 @@ internal sealed class TomlSerializedObjectFormatterResolver : ITomlValueFormatte
         => CacheCheck<T>.Registered;
 
     public void Register<T>(TomlSerializedObjectFormatter<T> fomatter)
-        where T : ITomlSerializedObject<T>
+        where T : class, ITomlSerializedObject<T?>
+    {
+        if (CacheCheck<T>.Registered) return;
+
+        CacheCheck<T>.Registered = true;
+        Cache<T>.Formatter = fomatter!;
+    }
+
+    public void Register<T>(StructTomlSerializedObjectFormatter<T> fomatter)
+        where T : struct, ITomlSerializedObject<T>
     {
         if (CacheCheck<T>.Registered) return;
 

--- a/src/CsToml/Formatter/Resolver/TomlValueFormatterResolver.cs
+++ b/src/CsToml/Formatter/Resolver/TomlValueFormatterResolver.cs
@@ -95,7 +95,13 @@ public sealed class TomlValueFormatterResolver : ITomlValueFormatterResolver
     }
 
     public static void Register<T>(TomlSerializedObjectFormatter<T> formatter)
-        where T : ITomlSerializedObject<T>
+        where T : class, ITomlSerializedObject<T?>
+    {
+        TomlSerializedObjectFormatterResolver.Instance.Register(formatter);
+    }
+
+    public static void Register<T>(StructTomlSerializedObjectFormatter<T> formatter)
+        where T : struct, ITomlSerializedObject<T>
     {
         TomlSerializedObjectFormatterResolver.Instance.Register(formatter);
     }

--- a/src/CsToml/Formatter/TomlSerializedObjectFormatter.cs
+++ b/src/CsToml/Formatter/TomlSerializedObjectFormatter.cs
@@ -2,16 +2,30 @@
 
 namespace CsToml.Formatter;
 
-public sealed class TomlSerializedObjectFormatter<T> : ITomlValueFormatter<T>
-    where T : ITomlSerializedObject<T>
+public sealed class TomlSerializedObjectFormatter<T> : ITomlValueFormatter<T?>
+    where T : class, ITomlSerializedObject<T?>
+{
+    public T? Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
+    {
+        return T.Deserialize(ref rootNode, options);
+    }
+
+    public void Serialize<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer, T? target, CsTomlSerializerOptions options)
+        where TBufferWriter : IBufferWriter<byte>
+    {
+        T.Serialize(ref writer, target, options);
+    }
+}
+
+public sealed class StructTomlSerializedObjectFormatter<T> : ITomlValueFormatter<T>
+    where T : struct, ITomlSerializedObject<T>
 {
     public T Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)
     {
         return T.Deserialize(ref rootNode, options);
     }
 
-    public void Serialize<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer, T target, CsTomlSerializerOptions options)
-        where TBufferWriter : IBufferWriter<byte>
+    public void Serialize<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer, T target, CsTomlSerializerOptions options) where TBufferWriter : IBufferWriter<byte>
     {
         T.Serialize(ref writer, target, options);
     }

--- a/src/CsToml/TomlDocument.cs
+++ b/src/CsToml/TomlDocument.cs
@@ -14,7 +14,7 @@ public partial class TomlDocument : ITomlValueFormatter<TomlDocument>
     private readonly TomlTable table;
 
     public TomlDocumentNode RootNode
-        => new(table.RootNode);
+        => new(table.RootNode, true);
 
     public long LineNumber { get; internal set; }
 

--- a/src/CsToml/TomlDocumentNode.cs
+++ b/src/CsToml/TomlDocumentNode.cs
@@ -25,6 +25,7 @@ public struct TomlDocumentNode
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly TomlValue value;
     private readonly TomlTableNode node;
+    private readonly bool isRoot;
 
     internal readonly int NodeCount => node?.NodeCount ?? 0;
 
@@ -32,13 +33,16 @@ public struct TomlDocumentNode
 
     internal readonly TomlTableNode Node => node;
 
-    public readonly bool HasValue => Value.HasValue || NodeCount > 0;
+    public readonly bool HasValue => Value.HasValue || NodeCount > 0 || isRoot;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly bool HasNodeOnly => !Value.HasValue && NodeCount > 0;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public readonly bool HasValueOnly => Value.HasValue && NodeCount == 0;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public readonly bool IsTableHeader => node?.IsTableHeader ?? false;
 
     public readonly TomlValueType ValueType => Value.Type;
 
@@ -110,10 +114,11 @@ public struct TomlDocumentNode
         }
     }
 
-    internal TomlDocumentNode(TomlTableNode node)
+    internal TomlDocumentNode(TomlTableNode node, bool isRoot = false)
     {
         this.node = node;
         this.value = node.Value!;
+        this.isRoot = isRoot;
     }
 
     public TomlDocumentNode(TomlValue value)

--- a/tests/CsToml.Generator.Tests/CsToml.Generator.Tests.csproj
+++ b/tests/CsToml.Generator.Tests/CsToml.Generator.Tests.csproj
@@ -15,8 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Utf8StringInterpolation" Version="1.3.2" />
     <PackageReference Include="xunit.v3" Version="1.1.0" />
   </ItemGroup>

--- a/tests/CsToml.Generator.Tests/Seirialization/SerializationTest.cs
+++ b/tests/CsToml.Generator.Tests/Seirialization/SerializationTest.cs
@@ -3297,6 +3297,9 @@ public class TypeImmutableTest2
             ImmutableArray = [new TypeTable3() { Value = "[1] This is TypeTable3 in ImmutableArray" },
                               new TypeTable3() { Value = "[2] This is TypeTable3 in ImmutableArray" },
                               new TypeTable3() { Value = "[3] This is TypeTable3 in ImmutableArray" }],
+            NullableImmutableArray = [new TypeTable3() { Value = "[1] This is TypeTable3 in NullableImmutableArray" },
+                                      new TypeTable3() { Value = "[2] This is TypeTable3 in NullableImmutableArray" },
+                                      new TypeTable3() { Value = "[3] This is TypeTable3 in NullableImmutableArray" }],
             ImmutableList = [new TypeTable3() { Value = "[1] This is TypeTable3 in ImmutableList" },
                               new TypeTable3() { Value = "[2] This is TypeTable3 in ImmutableList" },
                               new TypeTable3() { Value = "[3] This is TypeTable3 in ImmutableList" }],
@@ -3310,6 +3313,7 @@ public class TypeImmutableTest2
 
             using var buffer = Utf8String.CreateWriter(out var writer);
             writer.AppendLine("ImmutableArray = [ {Value = \"[1] This is TypeTable3 in ImmutableArray\"}, {Value = \"[2] This is TypeTable3 in ImmutableArray\"}, {Value = \"[3] This is TypeTable3 in ImmutableArray\"} ]");
+            writer.AppendLine("NullableImmutableArray = [ {Value = \"[1] This is TypeTable3 in NullableImmutableArray\"}, {Value = \"[2] This is TypeTable3 in NullableImmutableArray\"}, {Value = \"[3] This is TypeTable3 in NullableImmutableArray\"} ]");
             writer.AppendLine("ImmutableList = [ {Value = \"[1] This is TypeTable3 in ImmutableList\"}, {Value = \"[2] This is TypeTable3 in ImmutableList\"}, {Value = \"[3] This is TypeTable3 in ImmutableList\"} ]");
             writer.AppendLine("IImmutableList = [ {Value = \"[1] This is TypeTable3 in IImmutableList\"}, {Value = \"[2] This is TypeTable3 in IImmutableList\"}, {Value = \"[3] This is TypeTable3 in IImmutableList\"} ]");
             writer.Flush();
@@ -3322,6 +3326,7 @@ public class TypeImmutableTest2
 
             using var buffer = Utf8String.CreateWriter(out var writer);
             writer.AppendLine("ImmutableArray = [ {Value = \"[1] This is TypeTable3 in ImmutableArray\"}, {Value = \"[2] This is TypeTable3 in ImmutableArray\"}, {Value = \"[3] This is TypeTable3 in ImmutableArray\"} ]");
+            writer.AppendLine("NullableImmutableArray = [ {Value = \"[1] This is TypeTable3 in NullableImmutableArray\"}, {Value = \"[2] This is TypeTable3 in NullableImmutableArray\"}, {Value = \"[3] This is TypeTable3 in NullableImmutableArray\"} ]");
             writer.AppendLine("ImmutableList = [ {Value = \"[1] This is TypeTable3 in ImmutableList\"}, {Value = \"[2] This is TypeTable3 in ImmutableList\"}, {Value = \"[3] This is TypeTable3 in ImmutableList\"} ]");
             writer.AppendLine("IImmutableList = [ {Value = \"[1] This is TypeTable3 in IImmutableList\"}, {Value = \"[2] This is TypeTable3 in IImmutableList\"}, {Value = \"[3] This is TypeTable3 in IImmutableList\"} ]");
             writer.Flush();
@@ -3338,6 +3343,7 @@ public class TypeImmutableTest2
         writer.AppendLine("ImmutableArray = [ {Value = \"[1] This is TypeTable3 in ImmutableArray\"}, {Value = \"[2] This is TypeTable3 in ImmutableArray\"}, {Value = \"[3] This is TypeTable3 in ImmutableArray\"} ]");
         writer.AppendLine("ImmutableList = [ {Value = \"[1] This is TypeTable3 in ImmutableList\"}, {Value = \"[2] This is TypeTable3 in ImmutableList\"}, {Value = \"[3] This is TypeTable3 in ImmutableList\"} ]");
         writer.AppendLine("IImmutableList = [ {Value = \"[1] This is TypeTable3 in IImmutableList\"}, {Value = \"[2] This is TypeTable3 in IImmutableList\"}, {Value = \"[3] This is TypeTable3 in IImmutableList\"} ]");
+        writer.AppendLine("NullableImmutableArray = [ {Value = \"[1] This is TypeTable3 in NullableImmutableArray\"}, {Value = \"[2] This is TypeTable3 in NullableImmutableArray\"}, {Value = \"[3] This is TypeTable3 in NullableImmutableArray\"} ]");
         writer.Flush();
 
         var typeImmutable2 = CsTomlSerializer.Deserialize<TypeImmutable2>(buffer.WrittenSpan);
@@ -3356,6 +3362,11 @@ public class TypeImmutableTest2
         typeImmutable2.ImmutableArray[0].Value.ShouldBe("[1] This is TypeTable3 in ImmutableArray");
         typeImmutable2.ImmutableArray[1].Value.ShouldBe("[2] This is TypeTable3 in ImmutableArray");
         typeImmutable2.ImmutableArray[2].Value.ShouldBe("[3] This is TypeTable3 in ImmutableArray");
+
+        typeImmutable2.NullableImmutableArray!.Value.Length.ShouldBe(3);
+        typeImmutable2.NullableImmutableArray.Value[0].Value.ShouldBe("[1] This is TypeTable3 in NullableImmutableArray");
+        typeImmutable2.NullableImmutableArray.Value[1].Value.ShouldBe("[2] This is TypeTable3 in NullableImmutableArray");
+        typeImmutable2.NullableImmutableArray.Value[2].Value.ShouldBe("[3] This is TypeTable3 in NullableImmutableArray");
     }
 }
 
@@ -4020,6 +4031,32 @@ public class GenericTypeWhereStructTest
 
             var expected = buffer.ToArray();
             bytes.ByteSpan.ToArray().ShouldBe(expected);
+        }
+    }
+}
+
+public class NullableValueTest
+{
+    [Fact]
+    public void Deserialize()
+    {
+        {
+            var value = CsTomlSerializer.Deserialize<A>(@"
+Value = 12345
+
+[B]
+Name = ""This is B""
+"u8);
+            value.Value.ShouldBe(12345);
+            value.B.ShouldNotBeNull();
+            value.B!.Name.ShouldBe("This is B");
+        }
+        {
+            var value = CsTomlSerializer.Deserialize<A>(@""u8);
+
+            value.ShouldNotBeNull();
+            value.Value.ShouldBeNull();
+            value.B.ShouldBeNull();
         }
     }
 }

--- a/tests/CsToml.Generator.Tests/TypeDeclarations.cs
+++ b/tests/CsToml.Generator.Tests/TypeDeclarations.cs
@@ -834,6 +834,9 @@ internal partial class TypeImmutable2
     public ImmutableArray<TypeTable3> ImmutableArray { get; set; }
 
     [TomlValueOnSerialized]
+    public ImmutableArray<TypeTable3>? NullableImmutableArray { get; set; }
+
+    [TomlValueOnSerialized]
     public ImmutableList<TypeTable3> ImmutableList { get; set; }
 
     [TomlValueOnSerialized]

--- a/tests/CsToml.Generator.Tests/TypeDeclarations2.cs
+++ b/tests/CsToml.Generator.Tests/TypeDeclarations2.cs
@@ -68,3 +68,20 @@ internal partial struct SimpleStruct
     [TomlValueOnSerialized]
     public string Value { get; set; }
 }
+
+[TomlSerializedObject]
+public partial class A
+{
+    [TomlValueOnSerialized]
+    public B? B { get; set; }
+
+    [TomlValueOnSerialized]
+    public int? Value { get; set; }
+}
+
+[TomlSerializedObject]
+public partial class B
+{
+    [TomlValueOnSerialized]
+    public string Name { get; set; }
+}

--- a/tests/CsToml.Tests/CsToml.Tests.csproj
+++ b/tests/CsToml.Tests/CsToml.Tests.csproj
@@ -15,8 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Utf8StringInterpolation" Version="1.3.2" />
     <PackageReference Include="xunit.v3" Version="1.1.0" />
   </ItemGroup>

--- a/tests/CsToml.Tests/TomlDocumentExtensions.cs
+++ b/tests/CsToml.Tests/TomlDocumentExtensions.cs
@@ -115,7 +115,7 @@ internal static class TomlDocumentExtensions
                 Add(jsonObj, key, arrayJsonObj);
                 foreach (var v in arrayValue)
                 {
-                    AddChildTomlValue(arrayJsonObj, v, null);
+                    AddChildTomlValue(arrayJsonObj, v!, null);
                 }
                 break;
             case TomlTable tableValue: // Array of Tables


### PR DESCRIPTION
  This PR mainly fixes behavior where properties are not null when no values are present.
  
  - Add comprehensive nullable reference type support to the source generator
  - Separate struct and class formatter handling for better type safety
  - Remove unused NuGet dependencies from test projects
  - Fix nullable reference warnings

## Related issue
#62
