### PR TITLE
Update TomlFloat and DecimalFormatter

### DIFF
--- a/src/CsToml/Formatter/DecimalFormatter.cs
+++ b/src/CsToml/Formatter/DecimalFormatter.cs
@@ -1,9 +1,5 @@
 ﻿using CsToml.Error;
-using CsToml.Utility;
-using CsToml.Values;
 using System.Buffers;
-using System.Buffers.Text;
-using System.Globalization;
 
 namespace CsToml.Formatter;
 
@@ -18,34 +14,9 @@ internal sealed class DecimalFormatter : ITomlValueFormatter<decimal>
             return default!;
         }
 
-        var tomlValue = rootNode.Value;
-        if (tomlValue is TomlInteger)
+        if (rootNode.TryGetDouble(out var doubleValue))
         {
-            return tomlValue.GetInt64();
-        }
-        else
-        {
-            var bufferWriter = RecycleArrayPoolBufferWriter<byte>.Rent();
-
-            try
-            {
-                var length = 128;
-                var bytesWritten = 0;
-                while (!tomlValue.TryFormat(bufferWriter.GetSpan(length), out bytesWritten))
-                {
-                    length *= 2;
-                }
-                bufferWriter.Advance(bytesWritten);
-
-                if (Utf8Parser.TryParse(bufferWriter.WrittenSpan, out decimal value, out int bytesConsumed, '\0'))
-                {
-                    return value;
-                }
-            }
-            finally
-            {
-                RecycleArrayPoolBufferWriter<byte>.Return(bufferWriter);
-            }
+            return (decimal)doubleValue;
         }
 
         ExceptionHelper.ThrowDeserializationFailed(typeof(decimal));
@@ -55,26 +26,7 @@ internal sealed class DecimalFormatter : ITomlValueFormatter<decimal>
     public void Serialize<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer, decimal target, CsTomlSerializerOptions options)
         where TBufferWriter : IBufferWriter<byte>
     {
-        var bufferWriter = RecycleArrayPoolBufferWriter<byte>.Rent();
-        try
-        {
-            var length = 64;
-            var bytesWritten = 0;
-            if (target.TryFormat(bufferWriter.GetSpan(length), out bytesWritten))
-            {
-                bufferWriter.Advance(bytesWritten);
-                writer.WriteBytes(bufferWriter.WrittenSpan);
-            }
-            else
-            {
-                Utf8Helper.FromUtf16(bufferWriter, target.ToString(CultureInfo.InvariantCulture));
-                writer.WriteBytes(bufferWriter.WrittenSpan);
-            }
-        }
-        finally
-        {
-            RecycleArrayPoolBufferWriter<byte>.Return(bufferWriter);
-        }
+        writer.WriteDecimal(target);
     }
 }
 
@@ -86,35 +38,11 @@ internal sealed class NullableDecimalFormatter : ITomlValueFormatter<decimal?>
     {
         if (!rootNode.HasValue) return default;
 
-        var tomlValue = rootNode.Value;
-        if (tomlValue is TomlInteger)
+        if (rootNode.TryGetDouble(out var doubleValue))
         {
-            return tomlValue.GetInt64();
+            return (decimal)doubleValue;
         }
-        else
-        {
-            var bufferWriter = RecycleArrayPoolBufferWriter<byte>.Rent();
 
-            try
-            {
-                var length = 128;
-                var bytesWritten = 0;
-                while (!tomlValue.TryFormat(bufferWriter.GetSpan(length), out bytesWritten))
-                {
-                    length *= 2;
-                }
-                bufferWriter.Advance(bytesWritten);
-
-                if (Utf8Parser.TryParse(bufferWriter.WrittenSpan, out decimal value, out int bytesConsumed, '\0'))
-                {
-                    return value;
-                }
-            }
-            finally
-            {
-                RecycleArrayPoolBufferWriter<byte>.Return(bufferWriter);
-            }
-        }
         return null;
     }
 
@@ -123,26 +51,7 @@ internal sealed class NullableDecimalFormatter : ITomlValueFormatter<decimal?>
     {
         if (target.HasValue)
         {
-            var bufferWriter = RecycleArrayPoolBufferWriter<byte>.Rent();
-            try
-            {
-                var length = 64;
-                var bytesWritten = 0;
-                if (target.GetValueOrDefault().TryFormat(bufferWriter.GetSpan(length), out bytesWritten))
-                {
-                    bufferWriter.Advance(bytesWritten);
-                    writer.WriteBytes(bufferWriter.WrittenSpan);
-                }
-                else
-                {
-                    Utf8Helper.FromUtf16(bufferWriter, target.GetValueOrDefault().ToString(CultureInfo.InvariantCulture));
-                    writer.WriteBytes(bufferWriter.WrittenSpan);
-                }
-            }
-            finally
-            {
-                RecycleArrayPoolBufferWriter<byte>.Return(bufferWriter);
-            }
+            writer.WriteDecimal(target.GetValueOrDefault());
         }
         else
         {

--- a/src/CsToml/Utf8TomlDocumentWriter.cs
+++ b/src/CsToml/Utf8TomlDocumentWriter.cs
@@ -275,6 +275,19 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
         }
     }
 
+    public void WriteDecimal(decimal value)
+    {
+        var length = 64;
+        int bytesWritten;
+        var writtenSpan = writer.GetSpan(length);
+        while (!value.TryFormat(writtenSpan, out bytesWritten, default, CultureInfo.InvariantCulture))
+        {
+            length *= 2;
+            writtenSpan = writer.GetSpan(length);
+        }
+        writer.Advance(bytesWritten);
+    }
+
     public void WriteString(string? value)
     {
         if (string.IsNullOrEmpty(value))

--- a/src/CsToml/Values/TomlFloat.cs
+++ b/src/CsToml/Values/TomlFloat.cs
@@ -60,7 +60,7 @@ internal sealed partial class TomlFloat(double value) : TomlValue
     {
         if (bytes.Length < 3) ExceptionHelper.ThrowIncorrectTomlFloatFormat();
 
-        if (Utf8Parser.TryParse(bytes, out double value, out int _))
+        if (Utf8Parser.TryParse(bytes, out double value, out int bytesConsumed, 'G') && bytesConsumed == bytes.Length)
         {
             return new TomlFloat(value);
         }

--- a/src/CsToml/Values/TomlFloat.cs
+++ b/src/CsToml/Values/TomlFloat.cs
@@ -1,4 +1,5 @@
 ﻿using CsToml.Error;
+using System.Buffers.Text;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -59,7 +60,7 @@ internal sealed partial class TomlFloat(double value) : TomlValue
     {
         if (bytes.Length < 3) ExceptionHelper.ThrowIncorrectTomlFloatFormat();
 
-        if (double.TryParse(bytes, CultureInfo.InvariantCulture, out var value))
+        if (Utf8Parser.TryParse(bytes, out double value, out int _))
         {
             return new TomlFloat(value);
         }

--- a/tests/CsToml.Generator.Tests/Declarations/TypeDeclarations.cs
+++ b/tests/CsToml.Generator.Tests/Declarations/TypeDeclarations.cs
@@ -191,6 +191,28 @@ internal partial class TypeInteger
 }
 
 [TomlSerializedObject]
+internal partial class TypeDecimal
+{
+    [TomlValueOnSerialized]
+    public decimal IntegerValue { get; set; }
+
+    [TomlValueOnSerialized]
+    public decimal FloatValue { get; set; }
+
+    [TomlValueOnSerialized]
+    public decimal NegativeValue { get; set; }
+
+    [TomlValueOnSerialized]
+    public decimal ZeroValue { get; set; }
+
+    [TomlValueOnSerialized]
+    public decimal? NullableIntegerValue { get; set; }
+
+    [TomlValueOnSerialized]
+    public decimal? NullableFloatValue { get; set; }
+}
+
+[TomlSerializedObject]
 internal partial class TypeBuiltin
 {
     [TomlValueOnSerialized]

--- a/tests/CsToml.Generator.Tests/Generator/TypeDecimalTest.cs
+++ b/tests/CsToml.Generator.Tests/Generator/TypeDecimalTest.cs
@@ -1,4 +1,3 @@
-using CsToml.Error;
 using Shouldly;
 using Utf8StringInterpolation;
 

--- a/tests/CsToml.Generator.Tests/Generator/TypeDecimalTest.cs
+++ b/tests/CsToml.Generator.Tests/Generator/TypeDecimalTest.cs
@@ -1,0 +1,445 @@
+using CsToml.Error;
+using Shouldly;
+using Utf8StringInterpolation;
+
+namespace CsToml.Generator.Tests;
+
+public class TypeDecimalTest
+{
+    [Fact]
+    public void Serialize()
+    {
+        var decimalObj = new TypeDecimal()
+        {
+            IntegerValue = 999999,
+            FloatValue = 3.14m,
+            NegativeValue = -123.456m,
+            ZeroValue = 0,
+            NullableIntegerValue = 42,
+            NullableFloatValue = 1.5m,
+        };
+
+        using var bytes = CsTomlSerializer.Serialize(decimalObj);
+
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 999999");
+        writer.AppendLine("FloatValue = 3.14");
+        writer.AppendLine("NegativeValue = -123.456");
+        writer.AppendLine("ZeroValue = 0");
+        writer.AppendLine("NullableIntegerValue = 42");
+        writer.AppendLine("NullableFloatValue = 1.5");
+        writer.Flush();
+
+        var expected = buffer.ToArray();
+        bytes.ByteSpan.ToArray().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void DeserializeFromInteger()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 999999");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = -123");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe(999999m);
+        result.FloatValue.ShouldBe(0m);
+        result.NegativeValue.ShouldBe(-123m);
+        result.ZeroValue.ShouldBe(0m);
+    }
+
+    [Fact]
+    public void DeserializeFromFloat()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 0");
+        writer.AppendLine("FloatValue = 3.14");
+        writer.AppendLine("NegativeValue = -123.456");
+        writer.AppendLine("ZeroValue = 0.0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.FloatValue.ShouldBe((decimal)3.14);
+        result.NegativeValue.ShouldBe((decimal)(-123.456));
+        result.ZeroValue.ShouldBe(0m);
+    }
+
+    [Fact]
+    public void DeserializeNullable()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 0");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.AppendLine("NullableIntegerValue = 42");
+        writer.AppendLine("NullableFloatValue = 1.5");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.NullableIntegerValue.ShouldBe(42m);
+        result.NullableFloatValue.ShouldBe((decimal)1.5);
+    }
+
+    [Fact]
+    public void RoundTrip()
+    {
+        var original = new TypeDecimal()
+        {
+            IntegerValue = 123456,
+            FloatValue = 3.14m,
+            NegativeValue = -99.99m,
+            ZeroValue = 0,
+            NullableIntegerValue = 100,
+            NullableFloatValue = 2.5m,
+        };
+
+        using var bytes = CsTomlSerializer.Serialize(original);
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(bytes.ByteSpan);
+
+        result.IntegerValue.ShouldBe(original.IntegerValue);
+        result.NegativeValue.ShouldBe(original.NegativeValue);
+        result.ZeroValue.ShouldBe(original.ZeroValue);
+        result.NullableIntegerValue.ShouldBe(original.NullableIntegerValue);
+    }
+
+    // --- Edge Cases: Integer Boundaries ---
+
+    [Fact]
+    public void DeserializeFromInteger_LongMaxValue()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 9223372036854775807");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        // double cannot represent long.MaxValue exactly (> 2^53), so precision loss occurs
+        result.IntegerValue.ShouldBe((decimal)(double)long.MaxValue);
+    }
+
+    [Fact]
+    public void DeserializeFromInteger_LongMinValue()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = -9223372036854775808");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe((decimal)(double)long.MinValue);
+    }
+
+    [Fact]
+    public void DeserializeFromInteger_MinPositiveAndNegative()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 1");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = -1");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe(1m);
+        result.NegativeValue.ShouldBe(-1m);
+        result.ZeroValue.ShouldBe(0m);
+    }
+
+    // --- Edge Cases: Float Format Variations (ABNF: exp / frac [ exp ]) ---
+
+    [Fact]
+    public void DeserializeFromFloat_ExponentOnly()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 1e10");
+        writer.AppendLine("FloatValue = -2E-2");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe((decimal)1e10);
+        result.FloatValue.ShouldBe((decimal)(-2E-2));
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_ExponentWithLeadingZero()
+    {
+        // TOML spec: "1e06" — exponent part allows leading zeros
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 1e06");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe((decimal)1e6);
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_FracAndExp()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 6.626e-34");
+        writer.AppendLine("FloatValue = +1.0e+2");
+        writer.AppendLine("NegativeValue = -1.23e4");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe((decimal)6.626e-34);
+        result.FloatValue.ShouldBe((decimal)1.0e+2);
+        result.NegativeValue.ShouldBe((decimal)(-1.23e4));
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_PositiveSign()
+    {
+        // TOML spec: "+1.0" — explicit positive sign on float
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = +1.0");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = -0.01");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe(1.0m);
+        result.NegativeValue.ShouldBe((decimal)(-0.01));
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_Underscore()
+    {
+        // TOML spec: "224_617.445_991_228" — underscores enhance readability
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 224_617.445_991_228");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe((decimal)224617.445991228);
+    }
+
+    // --- Edge Cases: Special Float Values (ABNF: special-float) ---
+
+    [Fact]
+    public void DeserializeFromFloat_Inf_ThrowsOverflowException()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = inf");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        Should.Throw<OverflowException>(() =>
+            CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_PositiveInf_ThrowsOverflowException()
+    {
+        // TOML spec: "+inf" — explicit positive infinity
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = +inf");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        Should.Throw<OverflowException>(() =>
+            CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_NegativeInf_ThrowsOverflowException()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = -inf");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        Should.Throw<OverflowException>(() =>
+            CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_Nan_ThrowsOverflowException()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = nan");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        Should.Throw<OverflowException>(() =>
+            CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_PositiveNan_ThrowsOverflowException()
+    {
+        // TOML spec: "+nan" — same as nan
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = +nan");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        Should.Throw<OverflowException>(() =>
+            CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_NegativeNan_ThrowsOverflowException()
+    {
+        // TOML spec: "-nan" — valid, implementation-specific encoding
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = -nan");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        Should.Throw<OverflowException>(() =>
+            CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
+    }
+
+    // --- Edge Cases: Float Boundary Values ---
+
+    [Fact]
+    public void DeserializeFromFloat_SmallValue()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 1e-28");
+        writer.AppendLine("FloatValue = 0.0");
+        writer.AppendLine("NegativeValue = -0.0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe((decimal)1e-28);
+        result.FloatValue.ShouldBe(0m);
+        result.NegativeValue.ShouldBe(0m); // -0.0 as double → decimal becomes 0
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_PositiveZero()
+    {
+        // TOML spec: "+0.0" is valid and should map per IEEE 754
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = +0.0");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe(0m);
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_LargeExponent_ThrowsOverflowException()
+    {
+        // TOML spec: "5e+22" — valid TOML float but exceeds decimal range (~7.9e28)
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 5e+22");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        // 5e+22 fits in decimal range, should succeed
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe((decimal)5e+22);
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_ExceedDecimalRange_ThrowsOverflowException()
+    {
+        // 1e+29 exceeds decimal.MaxValue (~7.9e28)
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 1e+29");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        Should.Throw<OverflowException>(() =>
+            CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
+    }
+
+    // --- Edge Cases: Serialize Boundary Values ---
+
+    [Fact]
+    public void Serialize_DecimalMaxValue()
+    {
+        var decimalObj = new TypeDecimal()
+        {
+            IntegerValue = decimal.MaxValue,
+            FloatValue = 0,
+            NegativeValue = decimal.MinValue,
+            ZeroValue = 0,
+            NullableIntegerValue = 0,
+            NullableFloatValue = 0,
+        };
+
+        using var bytes = CsTomlSerializer.Serialize(decimalObj);
+
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 79228162514264337593543950335");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = -79228162514264337593543950335");
+        writer.AppendLine("ZeroValue = 0");
+        writer.AppendLine("NullableIntegerValue = 0");
+        writer.AppendLine("NullableFloatValue = 0");
+        writer.Flush();
+
+        var expected = buffer.ToArray();
+        bytes.ByteSpan.ToArray().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Serialize_SmallDecimalPrecision()
+    {
+        var decimalObj = new TypeDecimal()
+        {
+            IntegerValue = 0,
+            FloatValue = 0.0000000000000000000000000001m,
+            NegativeValue = 0,
+            ZeroValue = 0,
+            NullableIntegerValue = 0,
+            NullableFloatValue = 0,
+        };
+
+        using var bytes = CsTomlSerializer.Serialize(decimalObj);
+
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 0");
+        writer.AppendLine("FloatValue = 0.0000000000000000000000000001");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.AppendLine("NullableIntegerValue = 0");
+        writer.AppendLine("NullableFloatValue = 0");
+        writer.Flush();
+
+        var expected = buffer.ToArray();
+        bytes.ByteSpan.ToArray().ShouldBe(expected);
+    }
+}

--- a/tests/CsToml.Tests/DefaultTest.cs
+++ b/tests/CsToml.Tests/DefaultTest.cs
@@ -407,6 +407,62 @@ sf6 = -nan
         var document = CsTomlSerializer.Deserialize<TomlDocument>(@"flt1 = +1.0"u8);
         (document!.RootNode["flt1"].ValueType == TomlValueType.Float).ShouldBeTrue();
     }
+
+    [Fact]
+    public void MaxValue()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"v = 1.7976931348623157e+308"u8);
+        document!.RootNode["v"].GetDouble().ShouldBe(double.MaxValue);
+    }
+
+    [Fact]
+    public void MinValue()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"v = -1.7976931348623157e+308"u8);
+        document!.RootNode["v"].GetDouble().ShouldBe(double.MinValue);
+    }
+
+    [Fact]
+    public void Epsilon()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"v = 5e-324"u8);
+        document!.RootNode["v"].GetDouble().ShouldBe(double.Epsilon);
+    }
+
+    [Fact]
+    public void VerySmallPositive()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"v = 2.2250738585072014e-308"u8);
+        document!.RootNode["v"].GetDouble().ShouldBe(2.2250738585072014e-308);
+    }
+
+    [Fact]
+    public void VeryLargeExponent()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"v = 1.0e+300"u8);
+        document!.RootNode["v"].GetDouble().ShouldBe(1.0e+300);
+    }
+
+    [Fact]
+    public void VerySmallExponent()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"v = 1.0e-300"u8);
+        document!.RootNode["v"].GetDouble().ShouldBe(1.0e-300);
+    }
+
+    [Fact]
+    public void NegativeZero()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"v = -0.0"u8);
+        document!.RootNode["v"].GetDouble().ShouldBe(-0.0d);
+    }
+
+    [Fact]
+    public void LargeExponentWithDecimal()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(@"v = 1.23456789012345e+200"u8);
+        document!.RootNode["v"].GetDouble().ShouldBe(1.23456789012345e+200);
+    }
 }
 
 public class TomlBooleanTest


### PR DESCRIPTION
This PR change `TomlFloat` and `DecimalFormatter` process.

Change:
- TomlFloat: Utf8Parser.TryParse
- DecimalFormatter : TomlDocumentNode.TryGetDouble and Utf8TomlDocumentWriter.WriteDecimal

This change was created by Claude Code.