### PR TITLE
Add CsTomlFileSerializer.Deserialize/DeserializeAsync/Serialize/SerializeAsync overload accepting TomlFileExtensionPolicy

### DIFF
--- a/src/CsToml.Extensions/CsTomlFileSerializer.cs
+++ b/src/CsToml.Extensions/CsTomlFileSerializer.cs
@@ -2,6 +2,7 @@
 using CsToml.Extensions.Utility;
 using Cysharp.Collections;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 
 namespace CsToml.Extensions;
 
@@ -10,9 +11,11 @@ public partial class CsTomlFileSerializer
     private static readonly string TomlExtension = ".toml";
 
     public static T Deserialize<T>(string tomlFilePath, CsTomlSerializerOptions? options = null)
+        => Deserialize<T>(tomlFilePath, TomlFileExtensionPolicy.Strict, options);
+
+    public static T Deserialize<T>(string tomlFilePath, TomlFileExtensionPolicy extensionPolicy, CsTomlSerializerOptions? options = null)
     {
-        if (Path.GetExtension(tomlFilePath) != TomlExtension)
-            throw new FormatException($"TOML files should use the extension .toml");
+        ValidateExtension(tomlFilePath, extensionPolicy);
 
         using var handle = File.OpenHandle(tomlFilePath!, FileMode.Open, FileAccess.Read, options: FileOptions.SequentialScan);
         var length = RandomAccess.GetLength(handle);
@@ -54,10 +57,12 @@ public partial class CsTomlFileSerializer
         }
     }
 
-    public static async ValueTask<T> DeserializeAsync<T>(string tomlFilePath, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
+    public static ValueTask<T> DeserializeAsync<T>(string tomlFilePath, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
+        => DeserializeAsync<T>(tomlFilePath, TomlFileExtensionPolicy.Strict, options, configureAwait, cancellationToken);
+
+    public static async ValueTask<T> DeserializeAsync<T>(string tomlFilePath, TomlFileExtensionPolicy extensionPolicy, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
     {
-        if (Path.GetExtension(tomlFilePath) != TomlExtension)
-            throw new FormatException($"TOML files should use the extension .toml");
+        ValidateExtension(tomlFilePath, extensionPolicy);
 
         cancellationToken.ThrowIfCancellationRequested();
         using var handle = File.OpenHandle(tomlFilePath!, FileMode.Open, FileAccess.Read, options: FileOptions.SequentialScan | FileOptions.Asynchronous);
@@ -99,9 +104,11 @@ public partial class CsTomlFileSerializer
     }
 
     public static void Serialize<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options = null)
+        => Serialize<T>(tomlFilePath, value, TomlFileExtensionPolicy.Strict, options);
+
+    public static void Serialize<T>(string tomlFilePath, T value, TomlFileExtensionPolicy extensionPolicy, CsTomlSerializerOptions? options = null)
     {
-        if (Path.GetExtension(tomlFilePath) != TomlExtension)
-            throw new FormatException($"TOML file should use the extension .toml");
+        ValidateExtension(tomlFilePath, extensionPolicy);
 
         var directory = new FileInfo(tomlFilePath).Directory;
         if (!directory!.Exists)
@@ -116,10 +123,12 @@ public partial class CsTomlFileSerializer
         bufferWriter.WriteTo(fileWriter.ByteWriter);
     }
 
-    public static async ValueTask SerializeAsync<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
+    public static ValueTask SerializeAsync<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
+        => SerializeAsync<T>(tomlFilePath, value, TomlFileExtensionPolicy.Strict, options, configureAwait, cancellationToken);
+
+    public static async ValueTask SerializeAsync<T>(string tomlFilePath, T value, TomlFileExtensionPolicy extensionPolicy, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
     {
-        if (Path.GetExtension(tomlFilePath) != TomlExtension)
-            throw new FormatException($"TOML file should use the extension .toml");
+        ValidateExtension(tomlFilePath, extensionPolicy);
 
         var directory = new FileInfo(tomlFilePath).Directory;
         if (!directory!.Exists)
@@ -136,6 +145,18 @@ public partial class CsTomlFileSerializer
         await bufferWriter.WriteToAsync(fileWriter.ByteWriter, configureAwait, cancellationToken);
     }
 
+    private static void ValidateExtension(string tomlFilePath, TomlFileExtensionPolicy extensionPolicy)
+    {
+        if (extensionPolicy == TomlFileExtensionPolicy.Strict && Path.GetExtension(tomlFilePath) != TomlExtension)
+        {
+            ThrowExtensionFormatException();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowExtensionFormatException() 
+    {
+        throw new FormatException("TOML files should use the extension .toml");
+    }
+
 }
-
-

--- a/src/CsToml.Extensions/CsTomlFileSerializer.cs
+++ b/src/CsToml.Extensions/CsTomlFileSerializer.cs
@@ -11,9 +11,9 @@ public partial class CsTomlFileSerializer
     private static readonly string TomlExtension = ".toml";
 
     public static T Deserialize<T>(string tomlFilePath, CsTomlSerializerOptions? options = null)
-        => Deserialize<T>(tomlFilePath, TomlFileExtensionPolicy.Strict, options);
+        => Deserialize<T>(tomlFilePath, options, TomlFileExtensionPolicy.Strict);
 
-    public static T Deserialize<T>(string tomlFilePath, TomlFileExtensionPolicy extensionPolicy, CsTomlSerializerOptions? options = null)
+    public static T Deserialize<T>(string tomlFilePath, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy)
     {
         ValidateExtension(tomlFilePath, extensionPolicy);
 
@@ -58,9 +58,12 @@ public partial class CsTomlFileSerializer
     }
 
     public static ValueTask<T> DeserializeAsync<T>(string tomlFilePath, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
-        => DeserializeAsync<T>(tomlFilePath, TomlFileExtensionPolicy.Strict, options, configureAwait, cancellationToken);
+        => DeserializeAsyncCore<T>(tomlFilePath, options, TomlFileExtensionPolicy.Strict, configureAwait, cancellationToken);
 
-    public static async ValueTask<T> DeserializeAsync<T>(string tomlFilePath, TomlFileExtensionPolicy extensionPolicy, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
+    public static ValueTask<T> DeserializeAsync<T>(string tomlFilePath, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy, bool configureAwait = false, CancellationToken cancellationToken = default)
+        => DeserializeAsyncCore<T>(tomlFilePath, options, extensionPolicy, configureAwait, cancellationToken);
+
+    private static async ValueTask<T> DeserializeAsyncCore<T>(string tomlFilePath, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy, bool configureAwait, CancellationToken cancellationToken)
     {
         ValidateExtension(tomlFilePath, extensionPolicy);
 
@@ -104,9 +107,9 @@ public partial class CsTomlFileSerializer
     }
 
     public static void Serialize<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options = null)
-        => Serialize<T>(tomlFilePath, value, TomlFileExtensionPolicy.Strict, options);
+        => Serialize<T>(tomlFilePath, value, options, TomlFileExtensionPolicy.Strict);
 
-    public static void Serialize<T>(string tomlFilePath, T value, TomlFileExtensionPolicy extensionPolicy, CsTomlSerializerOptions? options = null)
+    public static void Serialize<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy)
     {
         ValidateExtension(tomlFilePath, extensionPolicy);
 
@@ -124,9 +127,12 @@ public partial class CsTomlFileSerializer
     }
 
     public static ValueTask SerializeAsync<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
-        => SerializeAsync<T>(tomlFilePath, value, TomlFileExtensionPolicy.Strict, options, configureAwait, cancellationToken);
+        => SerializeAsyncCore<T>(tomlFilePath, value, options, TomlFileExtensionPolicy.Strict, configureAwait, cancellationToken);
 
-    public static async ValueTask SerializeAsync<T>(string tomlFilePath, T value, TomlFileExtensionPolicy extensionPolicy, CsTomlSerializerOptions? options = null, bool configureAwait = false, CancellationToken cancellationToken = default)
+    public static ValueTask SerializeAsync<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy, bool configureAwait = false, CancellationToken cancellationToken = default)
+        => SerializeAsyncCore<T>(tomlFilePath, value, options, extensionPolicy, configureAwait, cancellationToken);
+
+    private static async ValueTask SerializeAsyncCore<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy, bool configureAwait, CancellationToken cancellationToken)
     {
         ValidateExtension(tomlFilePath, extensionPolicy);
 
@@ -147,9 +153,20 @@ public partial class CsTomlFileSerializer
 
     private static void ValidateExtension(string tomlFilePath, TomlFileExtensionPolicy extensionPolicy)
     {
-        if (extensionPolicy == TomlFileExtensionPolicy.Strict && Path.GetExtension(tomlFilePath) != TomlExtension)
+        switch (extensionPolicy)
         {
-            ThrowExtensionFormatException();
+            case TomlFileExtensionPolicy.Strict:
+                if (!string.Equals(Path.GetExtension(tomlFilePath), TomlExtension, StringComparison.Ordinal))
+                {
+                    ThrowExtensionFormatException();
+                }
+                break;
+            case TomlFileExtensionPolicy.Relaxed:
+                // No validation needed for relaxed policy
+                break;
+            default:
+                ThrowExtensionOutOfRangeException(extensionPolicy);
+                break;
         }
     }
 
@@ -159,4 +176,9 @@ public partial class CsTomlFileSerializer
         throw new FormatException("TOML files should use the extension .toml");
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowExtensionOutOfRangeException(TomlFileExtensionPolicy extensionPolicy)
+    {
+        throw new ArgumentOutOfRangeException(nameof(extensionPolicy));
+    }
 }

--- a/src/CsToml.Extensions/TomlFileExtensionPolicy.cs
+++ b/src/CsToml.Extensions/TomlFileExtensionPolicy.cs
@@ -1,0 +1,8 @@
+﻿
+namespace CsToml.Extensions;
+
+public enum TomlFileExtensionPolicy
+{
+    Strict = 0,
+    Relaxed = 1
+}

--- a/tests/CsToml.Tests/CsTomlFileSerializerExtensionPolicyTest.cs
+++ b/tests/CsToml.Tests/CsTomlFileSerializerExtensionPolicyTest.cs
@@ -37,7 +37,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
     {
         var filePath = CreateTomlFile("test.toml");
 
-        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Strict);
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Strict);
 
         doc.ShouldNotBeNull();
     }
@@ -48,7 +48,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var filePath = CreateTomlFile("test.conf");
 
         Should.Throw<FormatException>(() =>
-            CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Strict));
+            CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Strict));
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
     {
         var filePath = CreateTomlFile("test.toml");
 
-        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed);
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed);
 
         doc.ShouldNotBeNull();
     }
@@ -66,7 +66,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
     {
         var filePath = CreateTomlFile("test.conf");
 
-        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed);
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed);
 
         doc.ShouldNotBeNull();
     }
@@ -95,7 +95,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
     {
         var filePath = CreateTomlFile("test.toml");
 
-        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken);
+        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken);
 
         doc.ShouldNotBeNull();
     }
@@ -106,14 +106,14 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var filePath = CreateTomlFile("test.conf");
 
         await Should.ThrowAsync<FormatException>(async () =>
-            await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
+            await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public async ValueTask DeserializeAsync_Relaxed_WithTomlExtension_Succeeds()
     {
         var filePath = CreateTomlFile("test.toml");
-        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken);
+        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken);
         doc.ShouldNotBeNull();
     }
 
@@ -121,7 +121,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
     public async ValueTask DeserializeAsync_Relaxed_WithNonTomlExtension_Succeeds()
     {
         var filePath = CreateTomlFile("test.conf");
-        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken);
+        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken);
         doc.ShouldNotBeNull();
     }
 
@@ -149,7 +149,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         Should.NotThrow(() =>
-            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Strict));
+            CsTomlFileSerializer.Serialize(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Strict));
 
         File.Exists(filePath).ShouldBeTrue();
     }
@@ -161,7 +161,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         Should.Throw<FormatException>(() =>
-            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Strict));
+            CsTomlFileSerializer.Serialize(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Strict));
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         Should.NotThrow(() =>
-            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Relaxed));
+            CsTomlFileSerializer.Serialize(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed));
 
         File.Exists(filePath).ShouldBeTrue();
     }
@@ -183,7 +183,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         Should.NotThrow(() =>
-            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Relaxed));
+            CsTomlFileSerializer.Serialize(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed));
 
         File.Exists(filePath).ShouldBeTrue();
     }
@@ -217,7 +217,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         await Should.NotThrowAsync(async () =>
-            await CsTomlFileSerializer.SerializeAsync(filePath, doc, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
 
         File.Exists(filePath).ShouldBeTrue();
     }
@@ -229,7 +229,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         await Should.ThrowAsync<FormatException>(async () =>
-            await CsTomlFileSerializer.SerializeAsync(filePath, doc, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -239,7 +239,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         await Should.NotThrowAsync(async () =>
-            await CsTomlFileSerializer.SerializeAsync(filePath, doc, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken));
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken));
 
         File.Exists(filePath).ShouldBeTrue();
     }
@@ -251,7 +251,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         await Should.NotThrowAsync(async () =>
-            await CsTomlFileSerializer.SerializeAsync(filePath, doc, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken));
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken));
 
         File.Exists(filePath).ShouldBeTrue();
     }
@@ -287,7 +287,7 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
     {
         var filePath = CreateTomlFile(fileName);
 
-        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed);
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed);
 
         doc.ShouldNotBeNull();
     }
@@ -303,9 +303,47 @@ public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
         var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
 
         Should.NotThrow(() =>
-            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Relaxed));
+            CsTomlFileSerializer.Serialize(filePath, doc, CsTomlSerializerOptions.Default, TomlFileExtensionPolicy.Relaxed));
 
         File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Deserialize_UndefinedPolicy_ThrowsArgumentOutOfRangeException()
+    {
+        var filePath = CreateTomlFile("test.toml");
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, CsTomlSerializerOptions.Default, (TomlFileExtensionPolicy)99));
+    }
+
+    [Fact]
+    public async ValueTask DeserializeAsync_UndefinedPolicy_ThrowsArgumentOutOfRangeException()
+    {
+        var filePath = CreateTomlFile("test.toml");
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, CsTomlSerializerOptions.Default, (TomlFileExtensionPolicy)99, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Serialize_UndefinedPolicy_ThrowsArgumentOutOfRangeException()
+    {
+        var filePath = GetNonExistentPath("output.toml");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            CsTomlFileSerializer.Serialize(filePath, doc, CsTomlSerializerOptions.Default, (TomlFileExtensionPolicy)99));
+    }
+
+    [Fact]
+    public async ValueTask SerializeAsync_UndefinedPolicy_ThrowsArgumentOutOfRangeException()
+    {
+        var filePath = GetNonExistentPath("output.toml");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(async () =>
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, CsTomlSerializerOptions.Default, (TomlFileExtensionPolicy)99, cancellationToken: TestContext.Current.CancellationToken));
     }
 
 }

--- a/tests/CsToml.Tests/CsTomlFileSerializerExtensionPolicyTest.cs
+++ b/tests/CsToml.Tests/CsTomlFileSerializerExtensionPolicyTest.cs
@@ -1,0 +1,311 @@
+﻿using CsToml.Extensions;
+
+namespace CsToml.Tests;
+
+public class CsTomlFileSerializerExtensionPolicyTest : IDisposable
+{
+    private readonly string _tempDir;
+
+    public CsTomlFileSerializerExtensionPolicyTest()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"CsToml_Test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+    }
+
+    private string CreateTomlFile(string fileName, string content = "key = \"value\"")
+    {
+        var filePath = Path.Combine(_tempDir, fileName);
+        File.WriteAllBytes(filePath, System.Text.Encoding.UTF8.GetBytes(content));
+        return filePath;
+    }
+
+    private string GetNonExistentPath(string fileName)
+    {
+        return Path.Combine(_tempDir, fileName);
+    }
+
+    [Fact]
+    public void Deserialize_Strict_WithTomlExtension_Succeeds()
+    {
+        var filePath = CreateTomlFile("test.toml");
+
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Strict);
+
+        doc.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Deserialize_Strict_WithNonTomlExtension_ThrowsFormatException()
+    {
+        var filePath = CreateTomlFile("test.conf");
+
+        Should.Throw<FormatException>(() =>
+            CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Strict));
+    }
+
+    [Fact]
+    public void Deserialize_Relaxed_WithTomlExtension_Succeeds()
+    {
+        var filePath = CreateTomlFile("test.toml");
+
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed);
+
+        doc.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Deserialize_Relaxed_WithNonTomlExtension_Succeeds()
+    {
+        var filePath = CreateTomlFile("test.conf");
+
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed);
+
+        doc.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Deserialize_DefaultOverload_WithTomlExtension_Succeeds()
+    {
+        var filePath = CreateTomlFile("test.toml");
+
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath);
+
+        doc.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Deserialize_DefaultOverload_WithNonTomlExtension_ThrowsFormatException()
+    {
+        var filePath = CreateTomlFile("test.conf");
+
+        Should.Throw<FormatException>(() =>
+            CsTomlFileSerializer.Deserialize<TomlDocument>(filePath));
+    }
+
+    [Fact]
+    public async ValueTask DeserializeAsync_Strict_WithTomlExtension_Succeeds()
+    {
+        var filePath = CreateTomlFile("test.toml");
+
+        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken);
+
+        doc.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async ValueTask DeserializeAsync_Strict_WithNonTomlExtension_ThrowsFormatException()
+    {
+        var filePath = CreateTomlFile("test.conf");
+
+        await Should.ThrowAsync<FormatException>(async () =>
+            await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async ValueTask DeserializeAsync_Relaxed_WithTomlExtension_Succeeds()
+    {
+        var filePath = CreateTomlFile("test.toml");
+        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken);
+        doc.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async ValueTask DeserializeAsync_Relaxed_WithNonTomlExtension_Succeeds()
+    {
+        var filePath = CreateTomlFile("test.conf");
+        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken);
+        doc.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async ValueTask DeserializeAsync_DefaultOverload_WithTomlExtension_Succeeds()
+    {
+        var filePath = CreateTomlFile("test.toml");
+        var doc = await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, cancellationToken: TestContext.Current.CancellationToken);
+        doc.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async ValueTask DeserializeAsync_DefaultOverload_WithNonTomlExtension_ThrowsFormatException()
+    {
+        var filePath = CreateTomlFile("test.conf");
+
+        await Should.ThrowAsync<FormatException>(async () =>
+            await CsTomlFileSerializer.DeserializeAsync<TomlDocument>(filePath, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Serialize_Strict_WithTomlExtension_Succeeds()
+    {
+        var filePath = GetNonExistentPath("output.toml");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        Should.NotThrow(() =>
+            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Strict));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Serialize_Strict_WithNonTomlExtension_ThrowsFormatException()
+    {
+        var filePath = GetNonExistentPath("output.conf");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        Should.Throw<FormatException>(() =>
+            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Strict));
+    }
+
+    [Fact]
+    public void Serialize_Relaxed_WithTomlExtension_Succeeds()
+    {
+        var filePath = GetNonExistentPath("output.toml");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        Should.NotThrow(() =>
+            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Relaxed));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Serialize_Relaxed_WithNonTomlExtension_Succeeds()
+    {
+        var filePath = GetNonExistentPath("output.conf");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        Should.NotThrow(() =>
+            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Relaxed));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Serialize_DefaultOverload_WithTomlExtension_Succeeds()
+    {
+        var filePath = GetNonExistentPath("output.toml");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        Should.NotThrow(() =>
+            CsTomlFileSerializer.Serialize(filePath, doc));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Serialize_DefaultOverload_WithNonTomlExtension_ThrowsFormatException()
+    {
+        var filePath = GetNonExistentPath("output.conf");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        Should.Throw<FormatException>(() =>
+            CsTomlFileSerializer.Serialize(filePath, doc));
+    }
+
+    [Fact]
+    public async ValueTask SerializeAsync_Strict_WithTomlExtension_Succeeds()
+    {
+        var filePath = GetNonExistentPath("output.toml");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        await Should.NotThrowAsync(async () =>
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async ValueTask SerializeAsync_Strict_WithNonTomlExtension_ThrowsFormatException()
+    {
+        var filePath = GetNonExistentPath("output.conf");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        await Should.ThrowAsync<FormatException>(async () =>
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, TomlFileExtensionPolicy.Strict, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async ValueTask SerializeAsync_Relaxed_WithTomlExtension_Succeeds()
+    {
+        var filePath = GetNonExistentPath("output.toml");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        await Should.NotThrowAsync(async () =>
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async ValueTask SerializeAsync_Relaxed_WithNonTomlExtension_Succeeds()
+    {
+        var filePath = GetNonExistentPath("output.conf");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        await Should.NotThrowAsync(async () =>
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, TomlFileExtensionPolicy.Relaxed, cancellationToken: TestContext.Current.CancellationToken));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async ValueTask SerializeAsync_DefaultOverload_WithTomlExtension_Succeeds()
+    {
+        var filePath = GetNonExistentPath("output.toml");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        await Should.NotThrowAsync(async () =>
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, cancellationToken: TestContext.Current.CancellationToken));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async ValueTask SerializeAsync_DefaultOverload_WithNonTomlExtension_ThrowsFormatException()
+    {
+        var filePath = GetNonExistentPath("output.conf");
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        await Should.ThrowAsync<FormatException>(async () =>
+            await CsTomlFileSerializer.SerializeAsync(filePath, doc, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData("config.cfg")]
+    [InlineData("settings.ini")]
+    [InlineData("data.txt")]
+    [InlineData("noextension")]
+    public void Deserialize_Relaxed_WithVariousExtensions_Succeeds(string fileName)
+    {
+        var filePath = CreateTomlFile(fileName);
+
+        var doc = CsTomlFileSerializer.Deserialize<TomlDocument>(filePath, TomlFileExtensionPolicy.Relaxed);
+
+        doc.ShouldNotBeNull();
+    }
+
+    [Theory]
+    [InlineData("config.cfg")]
+    [InlineData("settings.ini")]
+    [InlineData("data.txt")]
+    [InlineData("noextension")]
+    public void Serialize_Relaxed_WithVariousExtensions_Succeeds(string fileName)
+    {
+        var filePath = GetNonExistentPath(fileName);
+        var doc = CsTomlSerializer.Deserialize<TomlDocument>("key = \"value\""u8);
+
+        Should.NotThrow(() =>
+            CsTomlFileSerializer.Serialize(filePath, doc, TomlFileExtensionPolicy.Relaxed));
+
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+}


### PR DESCRIPTION
#102

This PR add `CsTomlFileSerializer.Deserialize`/`DeserializeAsync`/`Serialize`/`SerializeAsync` overload accepting `TomlFileExtensionPolicy`.

```csharp
public partial class CsTomlFileSerializer
{
    public static T Deserialize<T>(string tomlFilePath, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy);
    public static ValueTask<T> DeserializeAsync<T>(string tomlFilePath, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy, bool configureAwait = false, CancellationToken cancellationToken = default);
    public static void Serialize<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy);
    public static ValueTask SerializeAsync<T>(string tomlFilePath, T value, CsTomlSerializerOptions? options, TomlFileExtensionPolicy extensionPolicy, bool configureAwait = false, CancellationToken cancellationToken = default);
}

public enum TomlFileExtensionPolicy
{
    Strict = 0,
    Relaxed = 1
}
```