### PR TITLE
Improvement

### DIFF
--- a/src/CsToml/Error/ExceptionHelper.cs
+++ b/src/CsToml/Error/ExceptionHelper.cs
@@ -6,14 +6,12 @@ namespace CsToml.Error;
 
 internal static class ExceptionHelper
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static T NotReturnThrow<T>(Action errorAction)
     {
         errorAction();
         return default!; // no return
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static T NotReturnThrow<T, T2>(Action<T2> errorAction, T2 args)
     {
         errorAction(args);
@@ -33,280 +31,280 @@ internal static class ExceptionHelper
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowNotSupported(string function)
     {
         ThrowException($"{function} is not supported.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowEndOfFileReached()
     {
         ThrowException($@"Reached end of file during processing.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowEndOfFileReachedAfterKey()
     {
         ThrowException($@"Reached end of file after key.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowInvalidAdvance()
     {
         ThrowException($@"Cannot advance past the end of the buffer.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowInvalidByteIncluded()
     {
         ThrowException($@"Invalid byte was included.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowBufferTooSmallFailed()
     {
         ThrowException($@"Destination buffer is Too Small to fail.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowFailedToParseToNumeric()
     {
         ThrowException($@"Failed to parse to numeric type because it is not syntactically valid.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowInvalidUnicodeScalarValue()
     {
         ThrowException($@"It contains Unicode code points outside the range U+0000 to U+10FFFF.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowDeserializationFailed(string message)
     {
-        ThrowException($@"Deserialization failed: ");
+        ThrowException($@"Deserialization failed: {message}");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowEscapeCharactersIncluded(byte unknownByte)
     {
         ThrowException($@"Escape characters {unknownByte} were included.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectCompactEscapeCharacters(byte unknownByte)
     {
         ThrowException($@"An invalid escape characters {unknownByte} were included.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowOverflowDuringParsingOfNumericTypes()
     {
         ThrowException($@"The value set is too large or too small.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowOverflowCount()
     {
         ThrowException($@"Value has overflowed.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowNumericConversionFailed(byte unknownByte)
     {
         ThrowException($@"{unknownByte} is a character that cannot be converted to a number.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowInvalidCasting()
     {
         ThrowException($@"Failed to cast to numeric value.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowNoValue()
     {
         ThrowException($@"There is no value.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowUnexpectedValueFound()
     {
         ThrowException($@"Unexpected value found.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlFormat()
     {
         ThrowException($@"Failed due to incorrect formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowNotSeparatedByCommas()
     {
         ThrowException($@"Values are not separated by commas.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTheArrayIsNotClosedWithClosingBrackets()
     {
         ThrowException($@"The array is not closed with closing brackets.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowInlineTableIsNotClosedWithClosingCurlyBrackets()
     {
         ThrowException($@"InlineTable is not closed with closing curly brackets.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTableHeaderIsNotClosedWithClosingBrackets()
     {
         ThrowException($@"Table Header is not closed with closing brackets.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowArrayOfTablesHeaderIsNotClosedWithClosingBrackets()
     {
         ThrowException($@"Array Of Tables Header is not closed with closing brackets.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowNotTurnIntoTable(string tableName)
     {
         ThrowException($@"Cannot be a table because the value is already defined in '{tableName}'");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTheKeyIsDefinedAsTable()
     {
         ThrowException($@"The key is already defined as a table.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTheKeyIsDefinedAsArrayOfTables()
     {
         ThrowException($@"Keys are already defined as an array of tables.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTheArrayOfTablesIsDefinedAsTable(string tableName)
     {
         ThrowException($@"The array of tables '{tableName}' is already defined as a table.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrect16bitCodePoint()
     {
         ThrowException($@"An incomplete '\uXXXX' escape sequence is specified.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrect32bitCodePoint()
     {
         ThrowException($@"An incomplete '\UXXXXXXXX' escape sequence is specified.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectPositiveAndNegativeSigns()
     {
         ThrowException($@" '+' or '-' are included in incorrect positions.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowThreeOrMoreQuotationMarks()
     {
         ThrowException($@"Three or more quotation marks are used in a string.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowInvalidEscapeSequence()
     {
         ThrowException($@"An invalid escape sequence was included.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowNoEqualAfterTheKey()
     {
         ThrowException($@"There was no ""="" after key.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectFormattingOfFloatingNumbers()
     {
         ThrowException($@"Failed due to incorrect formatting of floating numbers.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowConsecutiveQuotationMarksOf3()
     {
         ThrowException($@"Three or more quotation marks are written consecutively.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowConsecutiveSingleQuotationMarksOf3()
     {
         ThrowException($@"Three or more single quotes written consecutively.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTheEndIsNotClosedInThreeSingleQuotationMarks()
     {
         ThrowException("The end is not enclosed in three single quotation marks");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowKeyIsDefined(TomlDottedKey keyName)
     {
         ThrowException($@"Key '{keyName.Utf16String}' is already defined.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTableHeaderIsDefined(string keyName)
     {
         ThrowException($@"Table Header '{keyName}' is already defined.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTableHeaderIsDefinedAsArrayOfTables(string keyName)
     {
         ThrowException($@"Table Header '{keyName}' is already defined as Array of Tables.");
@@ -314,140 +312,140 @@ internal static class ExceptionHelper
 
     // Sub-table defined before parent of table or array of tables
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowOrderOfSubtableDefinitions(string tableName)
     {
         ThrowException($@"Sub-table '{tableName}' defined before parent of table or array of tables.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowUnderscoreUsedFirst()
     {
         ThrowException($@"Underscores are used first.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowUnderscoreUsedConsecutively()
     {
         ThrowException($@"Underscores are used consecutively.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowCommasAreUsedMoreThanOnce()
     {
         ThrowException($@"Commas are used more than once.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTheCommaIsDefinedFirst()
     {
         ThrowException($@"The comma is defined first.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowDotsAreUsedMoreThanOnce()
     {
         ThrowException($@"Dots are used more than once.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTheDotIsDefinedFirst()
     {
         ThrowException($@"The dot is defined first.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTheExponentPartUsedMoreThanOnce()
     {
         ThrowException($@"The exponent part e is used more than once.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowDecimalPointIsPresentAfterTheExponentialPartE()
     {
         ThrowException($@"A decimal point is present after the exponential part e");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowUnderscoreIsUsedAtTheEnd()
     {
         ThrowException($@"Underscores are used at the end.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowDotIsUsedAtTheEnd()
     {
         ThrowException($@"Dot is used at the end.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowKeysAreNotJoinedByDots()
     {
         ThrowException($@"Keys are not joined by dots.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowKeyisNotSpecifiedAfterDot()
     {
         ThrowException($@"Key is not specified after dot.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowExponentPartIsUsedAtTheEnd()
     {
         ThrowException($@"Exponent part is used at the end.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowSignIsUsedAtTheEnd()
     {
         ThrowException($@"Sign is used at the end.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowUnderscoreUsedWhereNotSurroundedByNumbers()
     {
         ThrowException($@"Underscores are used where they are not surrounded by numbers.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowDotIsUsedWhereNotSurroundedByNumbers()
     {
         ThrowException($@"Dot is used where they are not surrounded by numbers.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowExponentPartUsedWhereNotSurroundedByNumbers()
     {
         ThrowException($@"Exponent part are used where they are not surrounded by numbers.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowDotIsUsedFirst()
     {
         ThrowException($@"Dot is used first.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlBooleanFormat()
     {
         ThrowException($@"Failed due to incorrect Boolean formatting.");
@@ -455,220 +453,219 @@ internal static class ExceptionHelper
 
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlStringFormat()
     {
         ThrowException($@"Failed due to incorrect String formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlIntegerFormat()
     {
         ThrowException($@"Failed due to incorrect Integer formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlIntegerBinaryFormat()
     {
         ThrowException($@"Failed due to incorrect formatting of binary integers.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlIntegerOctalFormat()
     {
         ThrowException($@"Failed due to incorrect formatting of octal integers.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlIntegerHexadecimalFormat()
     {
         ThrowException($@"Failed due to incorrect formatting of hexadecimal integers.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlFloatFormat()
     {
         ThrowException($@"Failed due to incorrect Float formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlLocalDateTimeFormat()
     {
         ThrowException($@"Failed due to incorrect local DateTime formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlLocalDateFormat()
     {
         ThrowException($@"Failed due to incorrect local Date formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlLocalTimeFormat()
     {
         ThrowException($@"Failed due to incorrect local Time formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlOffsetDateTimeFormat()
     {
         ThrowException($@"Failed due to incorrect offset DateTime formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowIncorrectTomlInlineTableFormat()
     {
         ThrowException($@"Failed due to incorrect inline Table formatting.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowOverflow(Type t)
     {
         ThrowException($"value is not representable by {t}.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowArgumentOutOfRangeWhenOutsideTheBoundsOfTheArray()
     {
         ThrowException($"Index was outside the bounds of the array.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowArgumentOutOfRangeExceptionWhenCreating<T>(ArgumentOutOfRangeException innerException)
     {
         ThrowException($"ArgumentOutOfRangeException was thrown when creating {typeof(T)}.", innerException);
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowBasicStringsIsNotClosedWithClosingQuotationMarks()
     {
         ThrowException($@"Basic strings is not closed with closing quotation marks.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowMultilineBasicStringsIsNotClosedWithClosingThreeQuotationMarks()
     {
         ThrowException($@"Multi-line Basic strings is not closed with closing three quotation marks.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowLiteralStringsIsNotClosedWithClosingQuoted()
     {
         ThrowException($@"Literal strings is not closed with closing single quotes.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowInvalidCodePoints()
     {
         ThrowException($@"This byte array contains invalid Unicode code points.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowBareKeyIsEmpty()
     {
         ThrowException($@"Bare keys is empty.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowBareKeyContainsInvalid(byte ch)
     {
         ThrowException($@"Bare keys contains an invalid string '{ch}'.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowKeyContainsInvalid(byte ch)
     {
         ThrowException($@"Key contains an invalid string '{ch}'.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTableHeaderContainsInvalid(byte ch)
     {
         ThrowException($@"Table Header contains an invalid string '{ch}'.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowArrayOfTablesHeaderContainsInvalid(byte ch)
     {
         ThrowException($@"Array Of Tables Header contains an invalid string '{ch}'.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowNotRegisteredInResolver<T>()
     {
         ThrowNotRegisteredInResolver(typeof(T));
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowNotRegisteredInResolver(Type type)
     {
         ThrowException($@"{type.FullName} is not registered in Resolver.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowSerializationFailed(Type type)
     {
         ThrowException($@"Cannot serialize to {type}.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowSerializationFailedAsKey(Type type)
     {
         ThrowException($@"Cannot serialize to {type} as a key.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowDeserializationFailed(Type type)
     {
         ThrowException($@"Cannot deserialize to {type}.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowInvalidTupleCount()
     {
         ThrowException($@"Invalid Tuple count.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowOutOfMemory()
     {
         ThrowException($"Out of memory exception.");
     }
 
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void ThrowTrailingCommaIsNotAllowed()
     {
         ThrowException($@"After the last key/value pair in an inline table, a trailing comma is not allowed.");
     }
 }
-

--- a/src/CsToml/Extension/CollectionExtensions.cs
+++ b/src/CsToml/Extension/CollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 
@@ -9,21 +10,21 @@ internal static class CollectionExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T At<T>(this Span<T> span, int index)
     {
-        // Avoid range check.
+        Debug.Assert((uint)index < (uint)span.Length, $"Index {index} out of range [0, {span.Length})");
         return ref Unsafe.Add<T>(ref MemoryMarshal.GetReference(span), index);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T At<T>(this ReadOnlySpan<T> span, int index)
     {
-        // Avoid range check.
+        Debug.Assert((uint)index < (uint)span.Length, $"Index {index} out of range [0, {span.Length})");
         return ref Unsafe.Add<T>(ref MemoryMarshal.GetReference(span), index);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref T At<T>(this T[] array, int index)
     {
-        // Avoid range check.
+        Debug.Assert((uint)index < (uint)array.Length, $"Index {index} out of range [0, {array.Length})");
         return ref Unsafe.Add<T>(ref MemoryMarshal.GetArrayDataReference(array), index);
     }
 }

--- a/src/CsToml/TomlCodes.cs
+++ b/src/CsToml/TomlCodes.cs
@@ -2,6 +2,7 @@
 using CsToml.Error;
 using CsToml.Extension;
 using CsToml.Utility;
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -58,28 +59,55 @@ internal static class TomlCodes
                 -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 0xe0 - 0xef
                 -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 0xf0 - 0xff
             ];
-            return hexTable[hexNumber];
+            return hexTable.At(hexNumber);
         }
 
-        internal static int DigitsDecimalUnroll4(long value)
+        private static readonly ulong[] zeroOrPowersOf10 =
+        [
+            0,
+            0,
+            10,
+            100,
+            1000,
+            10000,
+            100000,
+            1000000,
+            10000000,
+            100000000,
+            1000000000,
+            10000000000,
+            100000000000,
+            1000000000000,
+            10000000000000,
+            100000000000000,
+            1000000000000000,
+            10000000000000000,
+            100000000000000000,
+            1000000000000000000,
+            10000000000000000000
+        ];
+
+        // https://github.com/fmtlib/fmt/blob/662adf4f33346ba9aba8b072194e319869ede54a/include/fmt/format.h#L1124
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int CountDigitsForInt64(long value)
         {
             // long.MinValue raises an OverflowException, so fixed support
             // https://learn.microsoft.com/en-us/dotnet/api/system.math.abs?view=net-8.0#system-math-abs(system-int64)
             if (value == long.MinValue)
                 return 19;
 
-            var number = 1;
-            value = Math.Abs(value);
+            ulong absValue = (ulong)(value < 0 ? -value : value);
 
-            for (; ; )
-            {
-                if (value < 10) return number;
-                if (value < 100) return number + 1;
-                if (value < 1000) return number + 2;
-                if (value < 10000) return number + 3;
-                value /= 10000;
-                number += 4;
-            }
+            ReadOnlySpan<byte> bsr2log10 =
+            [
+                 1,  1,  1,  2,  2,  2,  3,  3,  3,  4,  4,  4,  4,  5,  5,  5,
+                 6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  9,  9,  9, 10, 10, 10,
+                10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 15, 15,
+                15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 19, 20
+            ];
+
+            int t = bsr2log10.At((int)ulong.Log2(absValue));
+            return (int)(t - (absValue < zeroOrPowersOf10.At(t) ? 1 : 0));
         }
     }
 
@@ -181,7 +209,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return escapeTable[rawByte];
+        return escapeTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -206,7 +234,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return escapeSequenceTable[rawByte];
+        return escapeSequenceTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -231,7 +259,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return barekeyTable[rawByte];
+        return barekeyTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -278,6 +306,10 @@ internal static class TomlCodes
     internal static bool IsRightBraces(byte rawByte)
         => rawByte == Symbol.RIGHTBRACES;
 
+    internal static ReadOnlySpan<byte> TabOrWhiteSpaceOrNewlineBytes => [Symbol.TAB, Symbol.SPACE, Symbol.LINEFEED, Symbol.CARRIAGE];
+
+    internal static ReadOnlySpan<byte> TabOrWhiteSpaceBytes => [Symbol.TAB, Symbol.SPACE];
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool IsTabOrWhiteSpace(byte rawByte)
         => IsTab(rawByte) || IsWhiteSpace(rawByte);
@@ -308,7 +340,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return numberTable[rawByte];
+        return numberTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -333,7 +365,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return binaryTable[rawByte];
+        return binaryTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -358,7 +390,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return octalTable[rawByte];
+        return octalTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -383,7 +415,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return hexTable[rawByte];
+        return hexTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -409,7 +441,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return upperHexAlphabetTable[rawByte];
+        return upperHexAlphabetTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -435,7 +467,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return lowerHexAlphabetTable[rawByte];
+        return lowerHexAlphabetTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -461,7 +493,7 @@ internal static class TomlCodes
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xe0 - 0xef
             false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, // 0xf0 - 0xff
         ];
-        return alphabetTable[rawByte];
+        return alphabetTable.At(rawByte);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/CsToml/Utf8TomlDocumentWriter.cs
+++ b/src/CsToml/Utf8TomlDocumentWriter.cs
@@ -40,7 +40,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
     public readonly bool IsRoot => valueStates.Count == 1 && !valueOnly;
 
     internal Utf8TomlDocumentWriter(ref TBufferWriter bufferWriter, bool valueOnly = false) : this(ref bufferWriter, valueOnly, null)
-    {}
+    { }
 
     internal Utf8TomlDocumentWriter(ref TBufferWriter bufferWriter, bool valueOnly, CsTomlSerializerOptions? options)
     {
@@ -140,7 +140,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
 
     public void WriteInt64(long value)
     {
-        var length = TomlCodes.Number.DigitsDecimalUnroll4(value);
+        var length = TomlCodes.Number.CountDigitsForInt64(value);
         if (value < 0) length++;
 
         value.TryFormat(writer.GetWrittenSpan(length), out int bytesWritten, null, CultureInfo.InvariantCulture);
@@ -183,7 +183,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
         var writtenSpan = writer.GetWrittenSpan(digits);
         var index = digits - 1;
 
-        while (value > 0) 
+        while (value > 0)
         {
             var v = value & 7;
             writtenSpan[index--] = (byte)(TomlCodes.Number.Zero + (byte)v);
@@ -240,7 +240,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
 
     public void WriteDouble(double value)
     {
-        switch(value)
+        switch (value)
         {
             case double.NegativeInfinity:
                 WriteBytes("-inf"u8);
@@ -370,7 +370,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
             {
                 if (value.Microsecond == 0)
                 {
-                    var length = TomlCodes.Number.DigitsDecimalUnroll4(value.Millisecond);
+                    var length = TomlCodes.Number.CountDigitsForInt64(value.Millisecond);
                     switch (length)
                     {
                         case 1:
@@ -397,7 +397,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
                 }
                 else
                 {
-                    var length = TomlCodes.Number.DigitsDecimalUnroll4(value.Microsecond);
+                    var length = TomlCodes.Number.CountDigitsForInt64(value.Microsecond);
                     switch (length)
                     {
                         case 1:
@@ -434,7 +434,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
             {
                 if (value.Microsecond == 0)
                 {
-                    var length = TomlCodes.Number.DigitsDecimalUnroll4(value.Millisecond);
+                    var length = TomlCodes.Number.CountDigitsForInt64(value.Millisecond);
                     switch (length)
                     {
                         case 1:
@@ -461,7 +461,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
                 }
                 else
                 {
-                    var length = TomlCodes.Number.DigitsDecimalUnroll4(value.Microsecond);
+                    var length = TomlCodes.Number.CountDigitsForInt64(value.Microsecond);
                     switch (length)
                     {
                         case 1:
@@ -501,7 +501,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
         {
             if (value.Microsecond == 0)
             {
-                var length = TomlCodes.Number.DigitsDecimalUnroll4(value.Millisecond);
+                var length = TomlCodes.Number.CountDigitsForInt64(value.Millisecond);
                 switch (length)
                 {
                     case 1:
@@ -528,7 +528,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
             }
             else
             {
-                var length = TomlCodes.Number.DigitsDecimalUnroll4(value.Microsecond);
+                var length = TomlCodes.Number.CountDigitsForInt64(value.Microsecond);
                 switch (length)
                 {
                     case 1:
@@ -572,7 +572,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
         {
             if (value.Microsecond == 0)
             {
-                var length = TomlCodes.Number.DigitsDecimalUnroll4(value.Millisecond);
+                var length = TomlCodes.Number.CountDigitsForInt64(value.Millisecond);
                 switch (length)
                 {
                     case 1:
@@ -599,7 +599,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
             }
             else
             {
-                var length = TomlCodes.Number.DigitsDecimalUnroll4(value.Microsecond);
+                var length = TomlCodes.Number.CountDigitsForInt64(value.Microsecond);
                 switch (length)
                 {
                     case 1:
@@ -713,7 +713,7 @@ public ref struct Utf8TomlDocumentWriter<TBufferWriter>
                     fixed (byte* ptr = &destReference)
                     {
                         var writtenSpan = MemoryMarshal.CreateSpan(ref Unsafe.AsRef<byte>(ptr), bytesWritten);
-                        WriteKeyInternal(writtenSpan, TomlDottedKeyHelper.GetTomlKeyType( writtenSpan, options.Spec.SupportsEscapeSequenceE, options.Spec.SupportsEscapeSequenceX));
+                        WriteKeyInternal(writtenSpan, TomlDottedKeyHelper.GetTomlKeyType(writtenSpan, options.Spec.SupportsEscapeSequenceE, options.Spec.SupportsEscapeSequenceX));
                     }
                 }
             }

--- a/src/CsToml/Utility/SpanWriter.cs
+++ b/src/CsToml/Utility/SpanWriter.cs
@@ -1,13 +1,11 @@
 ﻿using CsToml.Error;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace CsToml.Utility;
 
-internal ref struct SpanWriter(Span<byte> buffer)
+internal ref struct SpanWriter(Span<byte> source)
 {
-    private readonly Span<byte> source = buffer;
-    private readonly ref byte refSource = ref MemoryMarshal.GetReference(buffer);
+    private readonly Span<byte> source = source;
     private int written = 0;
 
     public readonly int Written => written;
@@ -17,14 +15,13 @@ internal ref struct SpanWriter(Span<byte> buffer)
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(byte ch)
     {
-        if (written >= source.Length)
+        if ((uint)written >= (uint)source.Length)
         {
             ExceptionHelper.ThrowOverflowDuringParsingOfNumericTypes();
             return;
         }
 
-        ref var v = ref Unsafe.Add(ref refSource, written++);
-        v = ch;
+        source[written++] = ch;
     }
 
 }

--- a/src/CsToml/Utility/Utf8Helper.cs
+++ b/src/CsToml/Utility/Utf8Helper.cs
@@ -1,8 +1,8 @@
 ﻿using CsToml.Error;
 using System.Buffers;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Unicode;
 
 namespace CsToml.Utility;
@@ -281,7 +281,8 @@ internal static class Utf8Helper
     public static void FromUtf16(IBufferWriter<byte> writer, ReadOnlySpan<char> value)
     {
         // buffer size to 3 times worst-case (UTF16 -> UTF8)
-        var maxBufferSize = (value.Length + 1) * 3;
+        // var maxBufferSize = (value.Length + 1) * 3;
+        var maxBufferSize = Encoding.UTF8.GetMaxByteCount(value.Length);
 
         var status = Utf8.FromUtf16(value, writer.GetSpan(maxBufferSize),
             out int charsRead, out int bytesWritten, replaceInvalidSequences: false);
@@ -315,7 +316,7 @@ internal static class Utf8Helper
             return string.Empty;
         }
 
-        var maxBufferSize = utf8Bytes.Length * 2;
+        var maxBufferSize = utf8Bytes.Length;
         if (maxBufferSize <= 1024)
         {
             Span<char> bufferBytesSpan = stackalloc char[maxBufferSize];

--- a/src/CsToml/Values/TomlArray.cs
+++ b/src/CsToml/Values/TomlArray.cs
@@ -26,7 +26,7 @@ internal sealed partial class TomlArray(int capacity) : TomlValue, IEnumerable<T
     public TomlValue this[int index] => values[index];
 
     public TomlArray() : this(4)
-    {}
+    { }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<TomlValue> GetListSpan(int count)
@@ -81,7 +81,7 @@ internal sealed partial class TomlArray(int capacity) : TomlValue, IEnumerable<T
             if (arraySpan[i].TryFormat(destination.Slice(written), out var charsWritten2, format, provider))
             {
                 written += charsWritten2;
-                
+
                 if (destination.Length - written >= 3)
                 {
                     destination[written++] = ',';
@@ -162,7 +162,7 @@ internal sealed partial class TomlArray(int capacity) : TomlValue, IEnumerable<T
         public bool MoveNext()
         {
             var array = tomlArraySpan;
-            if (array.Length <= index) return false;
+            if ((uint)index >= (uint)array.Length) return false;
 
             this.Current = array[index];
             index++;
@@ -187,7 +187,7 @@ internal sealed partial class TomlArray(int capacity) : TomlValue, IEnumerable<T
         public bool MoveNext()
         {
             var array = tomlArray;
-            if (array.Count <= index) return false;
+            if ((uint)index >= (uint)array.Count) return false;
 
             this.Current = array[index];
             index++;

--- a/src/CsToml/Values/TomlInteger.cs
+++ b/src/CsToml/Values/TomlInteger.cs
@@ -17,7 +17,7 @@ internal abstract partial class TomlInteger : TomlValue
 {
     public static TomlInteger Zero => Cache<TomlDefaultInteger>.Values[1];
 
-    public long Value { get; init; } 
+    public long Value { get; init; }
 
     public override bool HasValue => true;
 
@@ -128,44 +128,20 @@ internal abstract partial class TomlInteger : TomlValue
 
         private static long ParseBinaryValue(ReadOnlySpan<byte> bytes)
         {
-            var digits = bytes.Length;
-            if (digits > 64) ExceptionHelper.ThrowOverflowCount();
+            var length = bytes.Length;
+            if (length > 64) ExceptionHelper.ThrowOverflowCount();
 
-            long value = 0;
-            int digitsCount = 1;
-            long baseValue = 1;
-            while (true)
+            ulong result = 0;
+            // Scalar remainder: left-to-right shift, one bit per digit.
+            for (int i = 0; i < length; i++)
             {
-                value += ParseBinaryByte(bytes[bytes.Length - digitsCount]) * baseValue;
-                if (value < 0) ExceptionHelper.ThrowOverflowCount();
-                if (digits == digitsCount++) return value;
-                baseValue *= 2;
-
-                value += ParseBinaryByte(bytes[bytes.Length - digitsCount]) * baseValue;
-                if (value < 0) ExceptionHelper.ThrowOverflowCount();
-                if (digits == digitsCount++) return value;
-                baseValue *= 2;
-
-                value += ParseBinaryByte(bytes[bytes.Length - digitsCount]) * baseValue;
-                if (value < 0) ExceptionHelper.ThrowOverflowCount();
-                if (digits == digitsCount++) return value;
-                baseValue *= 2;
-
-                value += ParseBinaryByte(bytes[bytes.Length - digitsCount]) * baseValue;
-                if (value < 0) ExceptionHelper.ThrowOverflowCount();
-                if (digits == digitsCount++) return value;
-                baseValue *= 2;
+                var b = bytes[i];
+                if (!TomlCodes.IsBinary(b)) ExceptionHelper.ThrowNumericConversionFailed(b);
+                result = (result << 1) | (b & 1u);
             }
 
-            static long ParseBinaryByte(byte utf8Byte)
-            {
-                if (!TomlCodes.IsBinary(utf8Byte))
-                {
-                    ExceptionHelper.ThrowNumericConversionFailed(utf8Byte);
-                }
-                return TomlCodes.Number.ParseDecimal(utf8Byte);
-            }
-
+            if ((long)result < 0) ExceptionHelper.ThrowOverflowCount();
+            return (long)result;
         }
 
         internal override void ToTomlString<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer)

--- a/src/CsToml/Values/TomlTableNodeDictionary.cs
+++ b/src/CsToml/Values/TomlTableNodeDictionary.cs
@@ -64,14 +64,14 @@ internal sealed class TomlTableNodeDictionary
 
         var index = bucket - 1;
         var collisionCount = 0;
-        while ((uint)index <= (uint)buckets.Length)
+        while ((uint)index <= (uint)entries.Length)
         {
             ref var e = ref entries[index];
             if (e.hashCode == hashCode && e.key.Equals(key))
                 return false;
 
             index = e.next;
-            if ((uint)buckets.Length < ++collisionCount)
+            if ((uint)entries.Length < ++collisionCount)
                 throw new Exception();
         }
 
@@ -94,21 +94,6 @@ internal sealed class TomlTableNodeDictionary
         return true;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryGetValueOrAdd(TomlDottedKey key, out TomlTableNode? existingValue, out TomlTableNode? addedValue)
-    {
-        var hashCode = key.GetHashCodeFast();
-        if (TryGetValueCore(key.Value, hashCode, out existingValue))
-        {
-            addedValue = null;
-            return true;
-        }
-
-        addedValue = new TomlTableNode() { IsGroupingProperty = true, Value = TomlValue.Empty };
-        TryAddCore(key, hashCode, addedValue);
-        return false;
-    }
-
     public AnalysisResults GetOrAddIfNotFound(TomlDottedKey key)
     {
         ref var buckets = ref this.buckets;
@@ -126,7 +111,7 @@ internal sealed class TomlTableNodeDictionary
         var index = bucket - 1;
         var collisionCount = 0;
 
-        while ((uint)index <= (uint)buckets.Length)
+        while ((uint)index <= (uint)entries.Length)
         {
             ref var e = ref entries[index];
             if (e.hashCode == hashCode && e.key.Equals(key))
@@ -135,7 +120,7 @@ internal sealed class TomlTableNodeDictionary
             }
 
             index = e.next;
-            if ((uint)buckets.Length < ++collisionCount)
+            if ((uint)entries.Length < ++collisionCount)
                 throw new Exception();
         }
 
@@ -186,7 +171,7 @@ internal sealed class TomlTableNodeDictionary
 
         do
         {
-            if ((uint)index > (uint)buckets.Length)
+            if ((uint)index > (uint)entries.Length)
             {
                 value = null;
                 return false;
@@ -223,7 +208,7 @@ internal sealed class TomlTableNodeDictionary
         this.entries.AsSpan().CopyTo(newEntriesSpan);
 
         this.buckets = new int[capacity];
-        for (int i = 0; i < count; i++)
+        for (int i = 0; i < newEntriesSpan.Length; i++)
         {
             if (newEntriesSpan[i].next >= -1)
             {
@@ -246,7 +231,7 @@ internal sealed class TomlTableNodeDictionary
 
     internal struct KeyValuePairEnumerator
     {
-        private readonly TomlTableNodeDictionary dictionary;
+        private readonly TomlTableNodeDictionary? dictionary;
         private int index;
         private KeyValuePair<TomlDottedKey, TomlTableNode> current;
 
@@ -254,7 +239,7 @@ internal sealed class TomlTableNodeDictionary
 
         public readonly KeyValuePairEnumerator GetEnumerator() => this;
 
-        internal KeyValuePairEnumerator(TomlTableNodeDictionary dict)
+        internal KeyValuePairEnumerator(TomlTableNodeDictionary? dict)
         {
             dictionary = dict;
             index = 0;
@@ -263,6 +248,13 @@ internal sealed class TomlTableNodeDictionary
 
         public bool MoveNext()
         {
+            if (dictionary == null)
+            {
+                index = -1;
+                current = default;
+                return false;
+            }
+
             while ((uint)index < (uint)dictionary.Count)
             {
                 ref var entry = ref dictionary.entries[index++];

--- a/src/CsToml/Values/TomlTableNodeDictionary.cs
+++ b/src/CsToml/Values/TomlTableNodeDictionary.cs
@@ -64,7 +64,7 @@ internal sealed class TomlTableNodeDictionary
 
         var index = bucket - 1;
         var collisionCount = 0;
-        while ((uint)index <= (uint)entries.Length)
+        while ((uint)index < (uint)entries.Length)
         {
             ref var e = ref entries[index];
             if (e.hashCode == hashCode && e.key.Equals(key))
@@ -111,7 +111,7 @@ internal sealed class TomlTableNodeDictionary
         var index = bucket - 1;
         var collisionCount = 0;
 
-        while ((uint)index <= (uint)entries.Length)
+        while ((uint)index < (uint)entries.Length)
         {
             ref var e = ref entries[index];
             if (e.hashCode == hashCode && e.key.Equals(key))


### PR DESCRIPTION
This PR change this following.

 - Suppress inlining optimization on exception helper methods
 - Improve out-of-bounds access safety using Debug.Assert and At extension methods
 - Speed up decimal digit counting
 - Optimize binary number parsing in `TomlBinaryInteger`
 - Optimize UTF-8 conversion buffers size