### PR TITLE
Improve performance reading basic strings processing

### DIFF
--- a/src/CsToml/CsTomlReader.cs
+++ b/src/CsToml/CsTomlReader.cs
@@ -820,6 +820,39 @@ internal ref struct CsTomlReader
     {
         Advance(1); // "
 
+        // Vectorized scan for the next control character / '"' / '\'.
+        // In the dominant case (closing quote in the current span, no escape sequence)
+        // the value is parsed directly from the slice without renting a buffer writer.
+        var unreadSpan = sequenceReader.UnreadSpan;
+        var index = unreadSpan.IndexOfAny(TomlCodes.BasicStringStopChars);
+        if (index >= 0)
+        {
+            var ch = unreadSpan.At(index);
+            if (TomlCodes.IsDoubleQuoted(ch))
+            {
+                var value = unreadSpan[..index];
+                if (Utf8Helper.ContainInvalidSequences(value))
+                    ExceptionHelper.ThrowInvalidCodePoints();
+
+                Advance(index + 1);
+                return T.Parse(value);
+            }
+            if (!TomlCodes.IsBackSlash(ch))
+            {
+                ExceptionHelper.ThrowEscapeCharactersIncluded(ch);
+            }
+        }
+
+        return ReadDoubleQuoteSingleLineStringSlow<T>(index);
+    }
+
+    private T ReadDoubleQuoteSingleLineStringSlow<T>(int index)
+        where T : TomlValue, ITomlStringParser<T>
+    {
+        // Escape sequence or segment boundary
+        // accumulate into a buffer writer, bulk-copying each clean run up to the next stop byte.
+        // index carries the scan result already computed for the current span by the fast path.
+
         var bufferWriter = RecycleArrayPoolBufferWriter<byte>.Rent();
         try
         {
@@ -828,36 +861,38 @@ internal ref struct CsTomlReader
 
             while (this.Peek())
             {
-                for (var index = 0; index < unreadSpan.Length; index++)
+                if (index < 0)
                 {
-                    var ch = unreadSpan[index];
-                    if (TomlCodes.IsEscape(ch))
-                    {
-                        ExceptionHelper.ThrowEscapeCharactersIncluded(ch);
-                    }
-                    else if (TomlCodes.IsDoubleQuoted(ch))
-                    {
-                        Advance(index + 1);
-                        closingQuotationMarks = true;
-                        goto BREAK;
-                    }
-                    else if (TomlCodes.IsBackSlash(ch))
-                    {
-                        Advance(index);
-                        ParseEscapeSequence(bufferWriter, multiLine: false);
-                        goto RESET;
-                    }
-                    bufferWriter.Write(ch);
-                }
-                Advance(unreadSpan.Length);
-                unreadSpan = sequenceReader.CurrentSpan;
-                continue;
+                    bufferWriter.Write(unreadSpan);
+                    Advance(unreadSpan.Length);
+                    unreadSpan = sequenceReader.CurrentSpan;
 
-            RESET:
+                    // Scan for the next control character.
+                    index = unreadSpan.IndexOfAny(TomlCodes.BasicStringStopChars);
+                    continue;
+                }
+
+                var ch = unreadSpan.At(index);
+                if (TomlCodes.IsDoubleQuoted(ch))
+                {
+                    bufferWriter.Write(unreadSpan[..index]);
+                    Advance(index + 1);
+                    closingQuotationMarks = true;
+                    break;
+                }
+                if (!TomlCodes.IsBackSlash(ch))
+                {
+                    ExceptionHelper.ThrowEscapeCharactersIncluded(ch);
+                }
+                bufferWriter.Write(unreadSpan[..index]);
+                Advance(index);
+                ParseEscapeSequence(bufferWriter, multiLine: false);
                 unreadSpan = sequenceReader.UnreadSpan;
+
+                // Scan for the next control character.
+                index = unreadSpan.IndexOfAny(TomlCodes.BasicStringStopChars);
             }
 
-        BREAK:
             if (!closingQuotationMarks)
                 ExceptionHelper.ThrowBasicStringsIsNotClosedWithClosingQuotationMarks();
 
@@ -1260,8 +1295,8 @@ internal ref struct CsTomlReader
         while (this.Peek())
         {
             // Vectorized scan
-            // TAB/SPACE/DOT/EQUAL are never bare key characters, so the first non-bare-key byte is either a terminator
-            // (or, for ']', a terminator only when parsing a table header) or invalid.
+            // TAB/SPACE/DOT/EQUAL are never bare key characters, so the first non-bare-key byte is either a terminator
+            // (or, for ']', a terminator only when parsing a table header) or invalid.
             var index = unreadSpan.IndexOfAnyExcept(TomlCodes.BareKeyChars);
             if (index >= 0)
             {

--- a/src/CsToml/TomlCodes.cs
+++ b/src/CsToml/TomlCodes.cs
@@ -241,6 +241,32 @@ internal static class TomlCodes
     internal static readonly SearchValues<byte> BareKeyChars =
         SearchValues.Create("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"u8);
 
+    // U+0000-U+0008 + U+000A-U+001F + '"' + '\'; used for vectorized scans (IndexOfAny) of basic strings.
+    internal static readonly SearchValues<byte> BasicStringStopChars = CreateBasicStringStopChars();
+
+    private static SearchValues<byte> CreateBasicStringStopChars()
+    {
+        Span<byte> stops = stackalloc byte[34];
+
+        var index = 0;
+
+        // U+0000-U+0008
+        for (var b = 0x00; b <= 0x08; b++)
+        {
+            stops[index++] = (byte)b;
+        }
+        // U+000A-U+001F
+        for (var b = 0x0a; b <= 0x1f; b++)
+        {
+            stops[index++] = (byte)b;
+        }
+
+        stops[index++] = 0x7f;                  // DEL
+        stops[index++] = Symbol.DOUBLEQUOTED;   // "
+        stops[index++] = Symbol.BACKSLASH;      // \
+        return SearchValues.Create(stops);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool IsBareKey(byte rawByte)
     {

--- a/tests/CsToml.Tests/BasicStringSlowPathTest.cs
+++ b/tests/CsToml.Tests/BasicStringSlowPathTest.cs
@@ -1,0 +1,143 @@
+﻿using CsToml.Error;
+using CsToml.Utility;
+using System.Buffers;
+using System.Text;
+
+namespace CsToml.Tests;
+
+public class BasicStringSlowPathTest
+{
+    private static ReadOnlySequence<byte> CreateSequence(params byte[][] chunks)
+    {
+        var first = new ByteSequenceSegment(chunks[0]);
+        var last = first;
+        for (var i = 1; i < chunks.Length; i++)
+        {
+            last = last.AddNext(chunks[i]);
+        }
+        return new ReadOnlySequence<byte>(first, 0, last, last.Length);
+    }
+
+    [Fact]
+    public void PlainContent_SplitAcrossTwoSegments()
+    {
+        var sequence = CreateSequence(
+            "value = \"abcde"u8.ToArray(),
+            "fghij\""u8.ToArray());
+
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(sequence);
+
+        document!.RootNode["value"u8].GetString().ShouldBe("abcdefghij");
+    }
+
+    [Fact]
+    public void PlainContent_SplitAcrossManySegments()
+    {
+        var sequence = CreateSequence(
+            "value = \"ab"u8.ToArray(),
+            "cd"u8.ToArray(),
+            "ef"u8.ToArray(),
+            "gh\""u8.ToArray());
+
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(sequence);
+
+        document!.RootNode["value"u8].GetString().ShouldBe("abcdefgh");
+    }
+
+    [Fact]
+    public void ClosingQuote_IsFirstByteOfNextSegment()
+    {
+        var sequence = CreateSequence(
+            "value = \"abcde"u8.ToArray(),
+            "\""u8.ToArray());
+
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(sequence);
+
+        document!.RootNode["value"u8].GetString().ShouldBe("abcde");
+    }
+
+    [Fact]
+    public void EscapeSequence_PrecededByPlainContentSplitAcrossSegments()
+    {
+        // "sta" | "rt" + \n(escape) + "end" + closing quote
+        var sequence = CreateSequence(
+            "value = \"sta"u8.ToArray(),
+            "rt\\nend\""u8.ToArray());
+
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(sequence);
+
+        document!.RootNode["value"u8].GetString().ShouldBe("start\nend");
+    }
+
+    [Fact]
+    public void EscapeSequence_BackslashAtSegmentBoundary()
+    {
+        // "ab" + '\' | 'n' + "cd" + closing quote
+        var sequence = CreateSequence(
+            "value = \"ab\\"u8.ToArray(),
+            "ncd\""u8.ToArray());
+
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(sequence);
+
+        document!.RootNode["value"u8].GetString().ShouldBe("ab\ncd");
+    }
+
+    [Fact]
+    public void UnescapedControlCharacter_InSecondSegment()
+    {
+        var chunk2 = new byte[] { 0x01 }.Concat("cd\""u8.ToArray()).ToArray();
+        var sequence = CreateSequence(
+            "value = \"ab"u8.ToArray(),
+            chunk2);
+
+        Should.Throw<CsTomlSerializeException>(() =>
+        {
+            CsTomlSerializer.Deserialize<TomlDocument>(sequence);
+        });
+    }
+
+    [Fact]
+    public void UnterminatedString_AcrossMultipleSegments()
+    {
+        var sequence = CreateSequence(
+            "value = \"abc"u8.ToArray(),
+            "def"u8.ToArray());
+
+        Should.Throw<CsTomlSerializeException>(() =>
+        {
+            CsTomlSerializer.Deserialize<TomlDocument>(sequence);
+        });
+    }
+
+    [Fact]
+    public void MultiByteUtf8Character_SplitAcrossSegmentBoundary()
+    {
+        // U+00E9 ('e' with acute accent) as UTF-8: 0xC3 0xA9, split between the two bytes.
+        var chunk1 = "value = \"caf"u8.ToArray().Concat(new byte[] { 0xC3 }).ToArray();
+        var chunk2 = new byte[] { 0xA9 }.Concat("\""u8.ToArray()).ToArray();
+        var sequence = CreateSequence(chunk1, chunk2);
+
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(sequence);
+
+        var expected = Encoding.UTF8.GetString([(byte)'c', (byte)'a', (byte)'f', 0xC3, 0xA9]);
+        document!.RootNode["value"u8].GetString().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void InvalidUtf8AfterEscapeSequence_Throws()
+    {
+        // \n (escape, forces the slow path) followed by a lone UTF-8 continuation byte
+        // (0x80), which is only checked once the slow path's accumulated buffer is
+        // validated at the end -- distinct from the fast path's check on a raw slice.
+        var bytes = "value = \""u8.ToArray()
+            .Concat("\\n"u8.ToArray())
+            .Concat(new byte[] { 0x80 })
+            .Concat("\""u8.ToArray())
+            .ToArray();
+
+        Should.Throw<CsTomlSerializeException>(() =>
+        {
+            CsTomlSerializer.Deserialize<TomlDocument>(bytes);
+        });
+    }
+}


### PR DESCRIPTION
This PR improves performance by changing a process based on `Span<T>` to a process using SIMD operations with `SearchValues.IndexOfAny`. 
I have also added test in `CsTomlReader.ReadDoubleQuoteSingleLineStringSlow`.

## Benchmark

| Method                   | Length | Escaped | Mean       | Error      | StdDev     | Median     | Ratio | RatioSD | BranchInstructions/Op | BranchMispredictions/Op | Code Size | Allocated | Alloc Ratio |
|------------------------- |------- |-------- |-----------:|-----------:|-----------:|-----------:|------:|--------:|----------------------:|------------------------:|----------:|----------:|------------:|
| **PerByteIfChain**           | **16**     | **False**   |  **24.634 ns** |  **2.5788 ns** |  **3.7800 ns** |  **25.854 ns** |  **1.02** |    **0.21** |                    **84** |                       **0** |     **272 B** |         **-** |          **NA** |
| StopSearchValuesBulkCopy | 16     | False   |   7.579 ns |  0.5605 ns |  0.8216 ns |   7.669 ns |  0.31 |    0.06 |                    21 |                       0 |   1,495 B |         - |          NA |
| StopSearchValuesNoCopy   | 16     | False   |   7.496 ns |  2.1189 ns |  3.1058 ns |   9.712 ns |  0.31 |    0.14 |                     9 |                       0 |     669 B |         - |          NA |
| StopSearchValuesNoCopyAt | 16     | False   |   7.888 ns |  2.3079 ns |  3.3099 ns |   8.884 ns |  0.33 |    0.14 |                     8 |                       0 |     654 B |         - |          NA |
|                          |        |         |            |            |            |            |       |         |                       |                         |           |           |             |
| **PerByteIfChain**           | **16**     | **True**    |  **26.275 ns** |  **2.1176 ns** |  **3.1695 ns** |  **25.480 ns** |  **1.01** |    **0.17** |                    **78** |                       **0** |     **271 B** |         **-** |          **NA** |
| StopSearchValuesBulkCopy | 16     | True    |  27.771 ns |  1.2466 ns |  1.8658 ns |  27.722 ns |  1.07 |    0.14 |                    76 |                       0 |   1,564 B |         - |          NA |
| StopSearchValuesNoCopy   | 16     | True    |  31.147 ns |  1.8695 ns |  2.7402 ns |  31.070 ns |  1.20 |    0.17 |                    76 |                       0 |   2,109 B |         - |          NA |
| StopSearchValuesNoCopyAt | 16     | True    |  29.880 ns |  1.2435 ns |  1.7833 ns |  29.973 ns |  1.15 |    0.15 |                    75 |                       0 |   2,094 B |         - |          NA |
|                          |        |         |            |            |            |            |       |         |                       |                         |           |           |             |
| **PerByteIfChain**           | **256**    | **False**   | **416.734 ns** | **31.6929 ns** | **47.4364 ns** | **419.079 ns** |  **1.01** |    **0.16** |                 **1,290** |                       **1** |     **272 B** |         **-** |          **NA** |
| StopSearchValuesBulkCopy | 256    | False   |  19.606 ns |  0.7630 ns |  1.1420 ns |  19.473 ns |  0.05 |    0.01 |                    44 |                       0 |   1,627 B |         - |          NA |
| StopSearchValuesNoCopy   | 256    | False   |  12.769 ns |  0.7697 ns |  1.1521 ns |  12.388 ns |  0.03 |    0.00 |                    25 |                       0 |     672 B |         - |          NA |
| StopSearchValuesNoCopyAt | 256    | False   |  13.115 ns |  0.8262 ns |  1.2366 ns |  13.086 ns |  0.03 |    0.00 |                    24 |                       0 |     659 B |         - |          NA |
|                          |        |         |            |            |            |            |       |         |                       |                         |           |           |             |
| **PerByteIfChain**           | **256**    | **True**    | **466.165 ns** | **39.6227 ns** | **59.3054 ns** | **467.914 ns** |  **1.02** |    **0.18** |                 **1,285** |                       **3** |     **271 B** |         **-** |          **NA** |
| StopSearchValuesBulkCopy | 256    | True    |  35.249 ns |  3.1163 ns |  4.6643 ns |  34.577 ns |  0.08 |    0.01 |                    94 |                       0 |   1,663 B |         - |          NA |
| StopSearchValuesNoCopy   | 256    | True    |  40.396 ns |  1.3345 ns |  1.9561 ns |  40.210 ns |  0.09 |    0.01 |                    96 |                       0 |   2,183 B |         - |          NA |
| StopSearchValuesNoCopyAt | 256    | True    |  42.210 ns |  4.5985 ns |  6.7405 ns |  38.633 ns |  0.09 |    0.02 |                    95 |                       0 |   2,170 B |         - |          NA |

<details><summary>Benchmark source</summary>

```csharp
public class BasicStringScan
{
    private const byte DoubleQuote = 0x22;
    private const byte BackSlash = 0x5C;

    // control chars + '"' + '\' (34 values)
    private static readonly SearchValues<byte> StopBytes = CreateStopBytes();

    // control chars only (32 values) — post-validation for the 2-value IndexOfAny candidate
    private static readonly SearchValues<byte> ControlBytes = CreateControlBytes();

    private static SearchValues<byte> CreateStopBytes()
    {
        Span<byte> stops = stackalloc byte[34];
        var n = 0;
        for (var b = 0x00; b <= 0x08; b++) { stops[n++] = (byte)b; }
        for (var b = 0x0A; b <= 0x1F; b++) { stops[n++] = (byte)b; }
        stops[n++] = 0x7F;
        stops[n++] = DoubleQuote;
        stops[n++] = BackSlash;
        return SearchValues.Create(stops[..n]);
    }

    private static SearchValues<byte> CreateControlBytes()
    {
        Span<byte> ctrl = stackalloc byte[32];
        var n = 0;
        for (var b = 0x00; b <= 0x08; b++) { ctrl[n++] = (byte)b; }
        for (var b = 0x0A; b <= 0x1F; b++) { ctrl[n++] = (byte)b; }
        ctrl[n++] = 0x7F;
        return SearchValues.Create(ctrl[..n]);
    }

    private byte[] buffer = [];
    private readonly LabWriter writer = new(1024);

    [Params(16, 256)]
    public int Length { get; set; }

    [Params(false, true)]
    public bool Escaped { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        // realistic ASCII content, closing quote, then trailing TOML
        ReadOnlySpan<byte> chars = "The quick brown fox jumps over the lazy dog 0123456789. "u8;
        ReadOnlySpan<byte> tail = "\r\nnext = 1"u8;
        buffer = new byte[Length + 1 + tail.Length];
        for (var i = 0; i < Length; i++)
        {
            buffer[i] = chars[i % chars.Length];
        }
        if (Escaped)
        {
            // two backslash escape pairs inside the content
            buffer[Length / 3] = BackSlash;
            buffer[Length / 3 + 1] = (byte)'n';
            buffer[Length * 2 / 3] = BackSlash;
            buffer[Length * 2 / 3 + 1] = (byte)'n';
        }
        buffer[Length] = DoubleQuote;
        tail.CopyTo(buffer.AsSpan(Length + 1));
    }

    // --- current implementation (CsTomlReader.ReadDoubleQuoteSingleLineString) ---

    // replica of TomlCodes.IsEscape: U+0000-U+0008, U+000A-U+001F, U+007F
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    private static bool IsEscape(byte rawByte)
    {
        ReadOnlySpan<bool> escapeTable =
        [
            true, true, true, true, true, true, true, true, true, false, true, true, true, true, true, true,                 // 0x00 - 0x0f
            true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,                  // 0x10 - 0x1f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0x20 - 0x2f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0x30 - 0x3f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0x40 - 0x4f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0x50 - 0x5f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0x60 - 0x6f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true,   // 0x70 - 0x7f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0x80 - 0x8f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0x90 - 0x9f
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0xa0 - 0xaf
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0xb0 - 0xbf
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0xc0 - 0xcf
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0xd0 - 0xdf
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0xe0 - 0xef
            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,  // 0xf0 - 0xff
        ];
        return Unsafe.Add(ref MemoryMarshal.GetReference(escapeTable), rawByte);
    }

    // Escape handling is simplified for all candidates alike: on '\', append the byte
    // after it and consume 2 bytes (stands in for ParseEscapeSequence, identical cost
    // across candidates so the comparison stays focused on the scan itself).

    [MethodImpl(MethodImplOptions.NoInlining)]
    [Benchmark(Baseline = true)]
    public int PerByteIfChain()
    {
        var writer = this.writer;
        writer.Reset();
        var span = buffer.AsSpan();
        for (var index = 0; index < span.Length; index++)
        {
            var ch = span[index];
            if (IsEscape(ch))
            {
                ThrowInvalid(ch);
            }
            else if (ch == DoubleQuote)
            {
                return writer.WrittenCount;
            }
            else if (ch == BackSlash)
            {
                writer.Write(span[index + 1]);
                index++;
                continue;
            }
            writer.Write(ch);
        }
        ThrowUnclosed();
        return -1;
    }

    // --- candidates ---

    [MethodImpl(MethodImplOptions.NoInlining)]
    [Benchmark]
    public int StopSearchValuesBulkCopy()
    {
        var writer = this.writer;
        writer.Reset();
        var span = buffer.AsSpan();
        while (true)
        {
            var idx = span.IndexOfAny(StopBytes);
            if (idx < 0)
            {
                ThrowUnclosed();
            }
            var ch = span[idx];
            if (ch == DoubleQuote)
            {
                writer.Write(span[..idx]);
                return writer.WrittenCount;
            }
            if (ch != BackSlash)
            {
                ThrowInvalid(ch);
            }
            writer.Write(span[..idx]);
            writer.Write(span[idx + 1]);
            span = span[(idx + 2)..];
        }
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    [Benchmark]
    public int QuoteBackslashThenValidate()
    {
        var writer = this.writer;
        writer.Reset();
        var span = buffer.AsSpan();
        while (true)
        {
            var idx = span.IndexOfAny(DoubleQuote, BackSlash);
            if (idx < 0)
            {
                ThrowUnclosed();
            }
            var content = span[..idx];
            if (content.ContainsAny(ControlBytes))
            {
                ThrowInvalid(0);
            }
            writer.Write(content);
            if (span[idx] == DoubleQuote)
            {
                return writer.WrittenCount;
            }
            writer.Write(span[idx + 1]);
            span = span[(idx + 2)..];
        }
    }

    // Fast path for the dominant case (no backslash before the closing quote):
    // the content is one clean slice, so skip the buffer writer entirely.
    // In production this means calling T.Parse(unreadSpan[..idx]) directly.
    [MethodImpl(MethodImplOptions.NoInlining)]
    [Benchmark]
    public int StopSearchValuesNoCopy()
    {
        var span = buffer.AsSpan();
        var idx = span.IndexOfAny(StopBytes);
        if (idx < 0)
        {
            ThrowUnclosed();
        }
        var ch = span[idx];
        if (ch == DoubleQuote)
        {
            return idx; // content length; production: T.Parse(span[..idx]), no writer rented
        }
        if (ch != BackSlash)
        {
            ThrowInvalid(ch);
        }
        return NoCopySlowPath(span, idx);
    }

    // Same as StopSearchValuesNoCopy but reads the stop byte via Unsafe.Add — the bounds
    // check after IndexOfAny (asm: cmp/jae -> CORINFO_HELP_RNGCHKFAIL) is provably redundant.
    // Matches the production shape, which uses span.At(idx).
    [MethodImpl(MethodImplOptions.NoInlining)]
    [Benchmark]
    public int StopSearchValuesNoCopyAt()
    {
        var span = buffer.AsSpan();
        var idx = span.IndexOfAny(StopBytes);
        if (idx < 0)
        {
            ThrowUnclosed();
        }
        var ch = Unsafe.Add(ref MemoryMarshal.GetReference(span), idx);
        if (ch == DoubleQuote)
        {
            return idx; // content length; production: T.Parse(span[..idx]), no writer rented
        }
        if (ch != BackSlash)
        {
            ThrowInvalid(ch);
        }
        return NoCopySlowPath(span, idx);
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    private int NoCopySlowPath(ReadOnlySpan<byte> span, int idx)
    {
        // from the first escape onwards, same as StopSearchValuesBulkCopy
        var writer = this.writer;
        writer.Reset();
        while (true)
        {
            writer.Write(span[..idx]);
            writer.Write(span[idx + 1]);
            span = span[(idx + 2)..];
            idx = span.IndexOfAny(StopBytes);
            if (idx < 0)
            {
                ThrowUnclosed();
            }
            var ch = span[idx];
            if (ch == DoubleQuote)
            {
                writer.Write(span[..idx]);
                return writer.WrittenCount;
            }
            if (ch != BackSlash)
            {
                ThrowInvalid(ch);
            }
        }
    }

    // replicates ArrayPoolBufferWriter<byte> write shapes (capacity check + Unsafe.Add store);
    // capacity is pre-sized so the grow path never runs, mirroring the rented-1024 steady state.
    private sealed class LabWriter(int capacity)
    {
        private readonly byte[] buffer = new byte[capacity];
        private int index;

        public int WrittenCount => index;

        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        public void Reset() => index = 0;

        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        public void Write(byte value)
        {
            if ((uint)index >= (uint)buffer.Length)
            {
                ThrowFull();
            }
            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(buffer), index++) = value;
        }

        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        public void Write(ReadOnlySpan<byte> value)
        {
            if ((uint)value.Length > (uint)(buffer.Length - index))
            {
                ThrowFull();
            }
            value.CopyTo(buffer.AsSpan(index, value.Length));
            index += value.Length;
        }

        [DoesNotReturn]
        [MethodImpl(MethodImplOptions.NoInlining)]
        private static void ThrowFull()
            => throw new InvalidOperationException("LabWriter capacity exceeded.");
    }

    [DoesNotReturn]
    [MethodImpl(MethodImplOptions.NoInlining)]
    private static void ThrowInvalid(byte ch)
        => throw new InvalidOperationException($"Invalid byte in basic string: 0x{ch:X2}");

    [DoesNotReturn]
    [MethodImpl(MethodImplOptions.NoInlining)]
    private static void ThrowUnclosed()
        => throw new InvalidOperationException("Basic string is not closed.");
}

```
</details>
