### PR TITLE
Optimize TOML parsing

### DIFF
--- a/src/CsToml/CsTomlParser.cs
+++ b/src/CsToml/CsTomlParser.cs
@@ -117,7 +117,7 @@ internal ref struct CsTomlParser
             if (reader.TryPeek(out var ch2))
             {
                 // skip newline
-                if (reader.TrySkipIfNewLine(ch2, true))
+                if (reader.TrySkipIfNewLine<CsTomlReader.ThrowControlCharacterMarker>(ch2))
                     return true;
 
                 if (CurrentState == ParserState.Comment)

--- a/src/CsToml/CsTomlReader.cs
+++ b/src/CsToml/CsTomlReader.cs
@@ -149,19 +149,19 @@ internal ref struct CsTomlReader
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ReadKeyResult ReadKey(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadKey(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         if (spec.AllowUnicodeInBareKeys)
         {
-            return ReadKeyToAllowUnicode(first, out key);
+            return ReadKeyToAllowUnicode(first, nodeHolder, out key);
         }
         else
         {
-            return ReadKeyToDisallowUnicode(first, out key);
+            return ReadKeyToDisallowUnicode(first, nodeHolder, out key);
         }
     }
 
-    internal ReadKeyResult ReadKeyToAllowUnicode(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadKeyToAllowUnicode(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         key = null;
 
@@ -171,11 +171,11 @@ internal ref struct CsTomlReader
         {
             if (TomlCodes.IsDoubleQuoted(ch))
             {
-                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>();
+                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>(nodeHolder);
             }
             else if (TomlCodes.IsSingleQuoted(ch))
             {
-                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>();
+                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>(nodeHolder);
             }
             else
             {
@@ -228,7 +228,7 @@ internal ref struct CsTomlReader
         return ReadKeyResult.Failed;
     }
 
-    internal ReadKeyResult ReadKeyToDisallowUnicode(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadKeyToDisallowUnicode(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         key = null;
 
@@ -239,15 +239,15 @@ internal ref struct CsTomlReader
             // The first character of a bare key must be a letter, digit, or underscore (A-Za-z0-9_-).
             if (TomlCodes.IsBareKey(ch))
             {
-                key = ReadUnquotedString<NotTableHeaderMarker>();
+                key = ReadUnquotedString<NotTableHeaderMarker>(nodeHolder);
             }
             else if (TomlCodes.IsDoubleQuoted(ch))
             {
-                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>();
+                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>(nodeHolder);
             }
             else if (TomlCodes.IsSingleQuoted(ch))
             {
-                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>();
+                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>(nodeHolder);
             }
             else
             {
@@ -303,19 +303,19 @@ internal ref struct CsTomlReader
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ReadKeyResult ReadTableHeaderKey(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadTableHeaderKey(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         if (spec.AllowUnicodeInBareKeys)
         {
-            return ReadTableHeaderKeyToAllowUnicode(first, out key);
+            return ReadTableHeaderKeyToAllowUnicode(first, nodeHolder, out key);
         }
         else
         {
-            return ReadTableHeaderKeyToDisallowUnicode(first, out key);
+            return ReadTableHeaderKeyToDisallowUnicode(first, nodeHolder, out key);
         }
     }
 
-    internal ReadKeyResult ReadTableHeaderKeyToAllowUnicode(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadTableHeaderKeyToAllowUnicode(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         key = null;
 
@@ -325,11 +325,11 @@ internal ref struct CsTomlReader
         {
             if (TomlCodes.IsDoubleQuoted(ch))
             {
-                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>();
+                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>(nodeHolder);
             }
             else if (TomlCodes.IsSingleQuoted(ch))
             {
-                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>();
+                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>(nodeHolder);
             }
             else
             {
@@ -382,7 +382,7 @@ internal ref struct CsTomlReader
         return ReadKeyResult.Failed;
     }
 
-    internal ReadKeyResult ReadTableHeaderKeyToDisallowUnicode(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadTableHeaderKeyToDisallowUnicode(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         key = null;
 
@@ -393,15 +393,15 @@ internal ref struct CsTomlReader
             // The first character of a bare key must be a letter, digit, or underscore (A-Za-z0-9_-).
             if (TomlCodes.IsBareKey(ch))
             {
-                key = ReadUnquotedString<TableHeaderMarker>();
+                key = ReadUnquotedString<TableHeaderMarker>(nodeHolder);
             }
             else if (TomlCodes.IsDoubleQuoted(ch))
             {
-                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>();
+                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>(nodeHolder);
             }
             else if (TomlCodes.IsSingleQuoted(ch))
             {
-                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>();
+                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>(nodeHolder);
             }
             else
             {
@@ -456,19 +456,19 @@ internal ref struct CsTomlReader
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ReadKeyResult ReadArrayOfTableHeaderKey(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadArrayOfTableHeaderKey(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         if (spec.AllowUnicodeInBareKeys)
         {
-            return ReadArrayOfTableHeaderKeyToAllowUnicode(first, out key);
+            return ReadArrayOfTableHeaderKeyToAllowUnicode(first, nodeHolder, out key);
         }
         else
         {
-            return ReadArrayOfTableKeyToDisallowUnicode(first, out key);
+            return ReadArrayOfTableKeyToDisallowUnicode(first, nodeHolder, out key);
         }
     }
 
-    internal ReadKeyResult ReadArrayOfTableHeaderKeyToAllowUnicode(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadArrayOfTableHeaderKeyToAllowUnicode(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         key = null;
 
@@ -478,11 +478,11 @@ internal ref struct CsTomlReader
         {
             if (TomlCodes.IsDoubleQuoted(ch))
             {
-                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>();
+                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>(nodeHolder);
             }
             else if (TomlCodes.IsSingleQuoted(ch))
             {
-                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>();
+                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>(nodeHolder);
             }
             else
             {
@@ -544,7 +544,7 @@ internal ref struct CsTomlReader
         return ReadKeyResult.Failed;
     }
 
-    internal ReadKeyResult ReadArrayOfTableKeyToDisallowUnicode(bool first, out TomlDottedKey? key)
+    internal ReadKeyResult ReadArrayOfTableKeyToDisallowUnicode(bool first, TomlTableNodeHolder nodeHolder, out TomlDottedKey? key)
     {
         key = null;
 
@@ -555,15 +555,15 @@ internal ref struct CsTomlReader
             // The first character of a bare key must be a letter, digit, or underscore (A-Za-z0-9_-).
             if (TomlCodes.IsBareKey(ch))
             {
-                key = ReadUnquotedString<TableHeaderMarker>();
+                key = ReadUnquotedString<TableHeaderMarker>(nodeHolder);
             }
             else if (TomlCodes.IsDoubleQuoted(ch))
             {
-                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>();
+                key = ReadDoubleQuoteSingleLineString<TomlBasicDottedKey>(nodeHolder);
             }
             else if (TomlCodes.IsSingleQuoted(ch))
             {
-                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>();
+                key = ReadSingleQuoteSingleLineString<TomlLiteralDottedKey>(nodeHolder);
             }
             else
             {
@@ -837,7 +837,7 @@ internal ref struct CsTomlReader
         {
             case 1:
             case 2:
-                return ReadDoubleQuoteSingleLineString<TomlBasicString>();
+                return ReadDoubleQuoteSingleLineString<TomlBasicString>(default);
             case 3:
             case 4:
             case 5:
@@ -856,7 +856,7 @@ internal ref struct CsTomlReader
         return ExceptionHelper.NotReturnThrow<TomlString>(ExceptionHelper.ThrowThreeOrMoreQuotationMarks);
     }
 
-    internal T ReadDoubleQuoteSingleLineString<T>()
+    internal T ReadDoubleQuoteSingleLineString<T>(TomlTableNodeHolder nodeHolder)
         where T : TomlValue, ITomlStringParser<T>
     {
         Advance(1); // "
@@ -876,7 +876,9 @@ internal ref struct CsTomlReader
                     ExceptionHelper.ThrowInvalidCodePoints();
 
                 Advance(index + 1);
-                return T.Parse(value);
+
+                return nodeHolder.GetKey<T>(value);
+                //return T.Parse(value);
             }
             if (!TomlCodes.IsBackSlash(ch))
             {
@@ -884,10 +886,10 @@ internal ref struct CsTomlReader
             }
         }
 
-        return ReadDoubleQuoteSingleLineStringSlow<T>(index);
+        return ReadDoubleQuoteSingleLineStringSlow<T>(index, nodeHolder);
     }
 
-    private T ReadDoubleQuoteSingleLineStringSlow<T>(int index)
+    private T ReadDoubleQuoteSingleLineStringSlow<T>(int index, TomlTableNodeHolder nodeHolder)
         where T : TomlValue, ITomlStringParser<T>
     {
         // Escape sequence or segment boundary
@@ -940,7 +942,8 @@ internal ref struct CsTomlReader
             if (Utf8Helper.ContainInvalidSequences(bufferWriter.WrittenSpan))
                 ExceptionHelper.ThrowInvalidCodePoints();
 
-            return T.Parse(bufferWriter.WrittenSpan);
+            return nodeHolder.GetKey<T>(bufferWriter.WrittenSpan);
+            //return T.Parse(bufferWriter.WrittenSpan);
         }
         finally
         {
@@ -1111,7 +1114,7 @@ internal ref struct CsTomlReader
         {
             case 1:
             case 2:
-                return ReadSingleQuoteSingleLineString<TomlLiteralString>();
+                return ReadSingleQuoteSingleLineString<TomlLiteralString>(default);
             case 3:
             case 4:
             case 5:
@@ -1130,7 +1133,7 @@ internal ref struct CsTomlReader
         return ExceptionHelper.NotReturnThrow<TomlString>(ExceptionHelper.ThrowConsecutiveSingleQuotationMarksOf3);
     }
 
-    internal T ReadSingleQuoteSingleLineString<T>()
+    internal T ReadSingleQuoteSingleLineString<T>(TomlTableNodeHolder nodeHolder)
         where T : TomlValue, ITomlStringParser<T>
     {
         Advance(1); // '
@@ -1175,14 +1178,17 @@ internal ref struct CsTomlReader
 
         if (fullSpan)
         {
-            return T.Parse(unreadSpan[..totalLength]);
+            return nodeHolder.GetKey<T>(unreadSpan[..totalLength]);
+            //return T.Parse(unreadSpan[..totalLength]);
         }
 
         try
         {
             if (Utf8Helper.ContainInvalidSequences(bufferWriter!.WrittenSpan))
                 ExceptionHelper.ThrowInvalidCodePoints();
-            return T.Parse(bufferWriter!.WrittenSpan);
+
+            return nodeHolder.GetKey<T>(bufferWriter!.WrittenSpan);
+            //return T.Parse(bufferWriter!.WrittenSpan);
         }
         finally
         {
@@ -1326,7 +1332,7 @@ internal ref struct CsTomlReader
         }
     }
 
-    internal TomlDottedKey ReadUnquotedString<TMarker>()
+    internal TomlDottedKey ReadUnquotedString<TMarker>(TomlTableNodeHolder nodeHolder)
         where TMarker : struct
     {
         var unreadSpan = sequenceReader.UnreadSpan;
@@ -1375,11 +1381,13 @@ internal ref struct CsTomlReader
     BREAK:
         if (fullSpan)
         {
-            return new TomlUnquotedDottedKey(unreadSpan[..totalLength]);
+            return nodeHolder.GetKey<TomlUnquotedDottedKey>(unreadSpan[..totalLength]);
+            //return new TomlUnquotedDottedKey(unreadSpan[..totalLength]);
         }
         try
         {
-            return new TomlUnquotedDottedKey(bufferWriter!.WrittenSpan);
+            return nodeHolder.GetKey<TomlUnquotedDottedKey>(bufferWriter!.WrittenSpan);
+            //return new TomlUnquotedDottedKey(bufferWriter!.WrittenSpan);
         }
         finally
         {
@@ -1621,11 +1629,11 @@ internal ref struct CsTomlReader
                 }
             }
 
-            var readResult = ReadKey(true, out var key);
+            var readResult = ReadKey(true, default, out var key);
             while (readResult == ReadKeyResult.FoundDot)
             {
                 node = node.GetOrAddKeyNode(key!);
-                readResult = ReadKey(false, out key);
+                readResult = ReadKey(false, default, out key);
 
                 while (TryPeek(out var numberSignCh) && numberSignCh == TomlCodes.Symbol.NUMBERSIGN)
                 {

--- a/src/CsToml/CsTomlReader.cs
+++ b/src/CsToml/CsTomlReader.cs
@@ -32,6 +32,42 @@ internal ref struct CsTomlReader
         LineNumber = 1;
     }
 
+    // Scanning past this window is pointless: TomlTableNodeDictionary.MaxInitialCapacity (1103)
+    // keys at a realistic line length already fit in 32KB, so the estimate saturates anyway.
+    private const int EstimateScanWindow = 32 * 1024;
+
+    public readonly int EstimateDirectKeyCount()
+    {
+        // Estimates how many key/value pairs follow before the next table header by counting '='
+        // bytes up to the next "\n[" occurrence. Multi-line strings, comments, dotted keys and
+        // inline tables make this an upper-bound estimate, not an exact count; it only seeds the
+        // node dictionary capacity and never affects parsing semantics.
+        if (!sequenceReader.IsFullSpan)
+        {
+            return 0;
+        }
+
+        var span = sequenceReader.UnreadSpan;
+        if (span.Length == 0 || span[0] == TomlCodes.Symbol.LEFTSQUAREBRACKET)
+        {
+            return 0;
+        }
+        if (span.Length > EstimateScanWindow)
+        {
+            span = span.Slice(0, EstimateScanWindow);
+        }
+
+        ReadOnlySpan<byte> nextHeader = [TomlCodes.Symbol.LINEFEED, TomlCodes.Symbol.LEFTSQUAREBRACKET];
+        var end = span.IndexOf(nextHeader);
+        if (end >= 0)
+        {
+            span = span.Slice(0, end);
+        }
+
+        // SIMD-accelerated count of '=' bytes in the span.
+        return span.Count(TomlCodes.Symbol.EQUAL);
+    }
+
     public TomlString ReadComment()
     {
         Advance(1); // #
@@ -203,7 +239,7 @@ internal ref struct CsTomlReader
             // The first character of a bare key must be a letter, digit, or underscore (A-Za-z0-9_-).
             if (TomlCodes.IsBareKey(ch))
             {
-                key = ReadUnquotedString(false);
+                key = ReadUnquotedString<NotTableHeaderMarker>();
             }
             else if (TomlCodes.IsDoubleQuoted(ch))
             {
@@ -357,7 +393,7 @@ internal ref struct CsTomlReader
             // The first character of a bare key must be a letter, digit, or underscore (A-Za-z0-9_-).
             if (TomlCodes.IsBareKey(ch))
             {
-                key = ReadUnquotedString(true);
+                key = ReadUnquotedString<TableHeaderMarker>();
             }
             else if (TomlCodes.IsDoubleQuoted(ch))
             {
@@ -519,7 +555,7 @@ internal ref struct CsTomlReader
             // The first character of a bare key must be a letter, digit, or underscore (A-Za-z0-9_-).
             if (TomlCodes.IsBareKey(ch))
             {
-                key = ReadUnquotedString(true);
+                key = ReadUnquotedString<TableHeaderMarker>();
             }
             else if (TomlCodes.IsDoubleQuoted(ch))
             {
@@ -667,7 +703,7 @@ internal ref struct CsTomlReader
     {
         while (TryPeek(out var ch))
         {
-            if (TrySkipIfNewLine(ch, false))
+            if (TrySkipIfNewLine<NotThrowControlCharacterMarker>(ch))
                 break;
             Advance(1);
         }
@@ -701,7 +737,8 @@ internal ref struct CsTomlReader
         }
     }
 
-    public bool TrySkipIfNewLine(byte ch, bool throwControlCharacter)
+    public bool TrySkipIfNewLine<TThrowControlCharacterMarker>(byte ch)
+        where TThrowControlCharacterMarker : struct
     {
         if (TomlCodes.IsLf(ch))
         {
@@ -719,16 +756,20 @@ internal ref struct CsTomlReader
             }
             if (TomlCodes.IsEscape(linebreakCh))
             {
-                if (throwControlCharacter)
+                if (typeof(TThrowControlCharacterMarker) == typeof(ThrowControlCharacterMarker))
+                {
                     ExceptionHelper.ThrowEscapeCharactersIncluded(linebreakCh);
+                }
                 return false;
             }
         }
 
         if (TomlCodes.IsEscape(ch))
         {
-            if (throwControlCharacter)
+            if (typeof(TThrowControlCharacterMarker) == typeof(ThrowControlCharacterMarker))
+            {
                 ExceptionHelper.ThrowEscapeCharactersIncluded(ch);
+            }
         }
 
         return false;
@@ -1285,7 +1326,8 @@ internal ref struct CsTomlReader
         }
     }
 
-    internal TomlDottedKey ReadUnquotedString(bool isTableHeader = false)
+    internal TomlDottedKey ReadUnquotedString<TMarker>()
+        where TMarker : struct
     {
         var unreadSpan = sequenceReader.UnreadSpan;
         var fullSpan = true;
@@ -1300,24 +1342,20 @@ internal ref struct CsTomlReader
             var index = unreadSpan.IndexOfAnyExcept(TomlCodes.BareKeyChars);
             if (index >= 0)
             {
+                // If ch is less than 64 (ulong bit size), we can use a single immediate bitmask to classify it as a terminator or not.
+                // TAB(0x09)/SPACE(0x20)/DOT(0x2E)/EQUAL(0x3D) are all < 64 are all, it can be represented using terminatorBitMask.
+                // ']' (0x5D) is a terminator only for table headers.
+                const ulong terminatorBitMask =
+                    (1UL << TomlCodes.Symbol.TAB) | (1UL << TomlCodes.Symbol.SPACE) |
+                    (1UL << TomlCodes.Symbol.DOT) | (1UL << TomlCodes.Symbol.EQUAL);
+
                 var ch = unreadSpan.At(index);
-                switch (ch)
+                var isTerminator = ch < 64
+                    ? ((terminatorBitMask >> ch) & 1) != 0
+                    : typeof(TMarker) == typeof(TableHeaderMarker) && ch == TomlCodes.Symbol.RIGHTSQUAREBRACKET;
+                if (!isTerminator)
                 {
-                    case TomlCodes.Symbol.TAB:
-                    case TomlCodes.Symbol.SPACE:
-                    case TomlCodes.Symbol.DOT:
-                    case TomlCodes.Symbol.EQUAL:
-                        break;
-                    case TomlCodes.Symbol.RIGHTSQUAREBRACKET:
-                        if (isTableHeader)
-                        {
-                            break;
-                        }
-                        ExceptionHelper.ThrowBareKeyContainsInvalid(ch);
-                        break;
-                    default:
-                        ExceptionHelper.ThrowBareKeyContainsInvalid(ch);
-                        break;
+                    ExceptionHelper.ThrowBareKeyContainsInvalid(ch);
                 }
                 if (!fullSpan)
                 {
@@ -1423,6 +1461,11 @@ internal ref struct CsTomlReader
 
     internal TomlArray ReadArray()
     {
+        // Array-level specials: TAB, LF, CR, SPACE, '#', ',', '[', ']'. Any other byte starts a value.
+        // '['=0x5B and ']'=0x5D exceed a single ulong mask, hence two words selected by ch < 64.
+        const ulong ArraySpecialBitMask0 = (1UL << TomlCodes.Symbol.TAB) | (1UL << TomlCodes.Symbol.LINEFEED) | (1UL << TomlCodes.Symbol.CARRIAGE) | (1UL << TomlCodes.Symbol.SPACE) | (1UL << TomlCodes.Symbol.NUMBERSIGN) | (1UL << TomlCodes.Symbol.COMMA);
+        const ulong ArraySpecialBitMask1 = (1UL << (TomlCodes.Symbol.LEFTSQUAREBRACKET - 64)) | (1UL << (TomlCodes.Symbol.RIGHTSQUAREBRACKET - 64));
+
         Advance(1); // [
 
         var initialArray = default(InlineArray16<TomlValue>);
@@ -1432,21 +1475,34 @@ internal ref struct CsTomlReader
         var comma = true;
         var commaCount = 0;
         var closingBracket = false;
-        while (TryPeek(out var ch))
+        while (Peek())
         {
-            switch (ch)
+            // Scan the current segment with a local index so a run of delimiters costs a single
+            // Advance and the position stays in a register. Peek() == true guarantees a non-empty
+            // UnreadSpan (Advance rolls into the next segment when the current one is exhausted).
+            var unreadSpan = sequenceReader.UnreadSpan;
+            var index = 0;
+            while (index < unreadSpan.Length)
             {
-                case TomlCodes.Symbol.LEFTSQUAREBRACKET:
+                var ch = unreadSpan.At(index);
+                if (!IsArraySpecial(ch))
+                {
+                    Advance(index);
+                    if (!comma) ExceptionHelper.ThrowNotSeparatedByCommas();
                     comma = false;
-                    arrayBuilder.Add(ReadArray());
-                    break;
-                case TomlCodes.Symbol.TAB:
-                case TomlCodes.Symbol.SPACE:
-                    SkipWhiteSpace();
-                    break;
-                case TomlCodes.Symbol.COMMA:
+                    arrayBuilder.Add(ReadValue());
+                    goto RESCAN;
+                }
+                if (ch is TomlCodes.Symbol.SPACE or TomlCodes.Symbol.TAB)
+                {
+                    index++;
+                    continue;
+                }
+                if (ch == TomlCodes.Symbol.COMMA)
+                {
                     if (comma)
                     {
+                        Advance(index);
                         if (commaCount > 0)
                             ExceptionHelper.ThrowCommasAreUsedMoreThanOnce();
                         else
@@ -1454,38 +1510,56 @@ internal ref struct CsTomlReader
                     }
                     comma = true;
                     commaCount++;
-                    Advance(1);
-                    break;
-                case TomlCodes.Symbol.CARRIAGE:
-                    Advance(1);
-                    if (TryPeek(out var linebreakCh) && TomlCodes.IsLf(linebreakCh))
+                    index++;
+                    continue;
+                }
+                if (ch == TomlCodes.Symbol.RIGHTSQUAREBRACKET)
+                {
+                    closingBracket = true;
+                    Advance(index + 1);
+                    goto BREAK;
+                }
+                if (ch == TomlCodes.Symbol.LINEFEED)
+                {
+                    index++;
+                    if (index < unreadSpan.Length)
                     {
-                        Advance(1);
-                        IncreaseLineNumber();
+                        LineNumber++; // more bytes follow in this segment, so not EOF
                         continue;
                     }
-                    return ExceptionHelper.NotReturnThrow<TomlArray, byte>(ExceptionHelper.ThrowEscapeCharactersIncluded, ch);
-                case TomlCodes.Symbol.LINEFEED:
+                    Advance(index);
+                    IncreaseLineNumber();
+                    goto RESCAN;
+                }
+
+                // Rare specials ('[', '#', CR): sync the reader and use the reader-based logic.
+                Advance(index);
+                if (ch == TomlCodes.Symbol.LEFTSQUAREBRACKET)
+                {
+                    comma = false;
+                    arrayBuilder.Add(ReadArray());
+                    goto RESCAN;
+                }
+                if (ch == TomlCodes.Symbol.NUMBERSIGN)
+                {
+                    ReadComment();
+                    goto RESCAN;
+                }
+                // CR
+                Advance(1);
+                if (TryPeek(out var linebreakCh) && TomlCodes.IsLf(linebreakCh))
+                {
                     Advance(1);
                     IncreaseLineNumber();
-                    continue;
-                case TomlCodes.Symbol.RIGHTSQUAREBRACKET:
-                    closingBracket = true;
-                    Advance(1);
-                    goto BREAK;
-                case TomlCodes.Symbol.NUMBERSIGN:
-                    ReadComment();
-                    break;
-                default:
-                    if (!comma) ExceptionHelper.ThrowNotSeparatedByCommas();
-                    comma = false;
-                    arrayBuilder.Add(ReadValue());
-                    break;
+                    goto RESCAN;
+                }
+                return ExceptionHelper.NotReturnThrow<TomlArray, byte>(ExceptionHelper.ThrowEscapeCharactersIncluded, ch);
             }
-            continue;
-        BREAK:
-            break;
+            Advance(unreadSpan.Length);
+        RESCAN:
+            ;
         }
+    BREAK:
 
         if (!closingBracket)
             ExceptionHelper.ThrowTheArrayIsNotClosedWithClosingBrackets();
@@ -1498,6 +1572,12 @@ internal ref struct CsTomlReader
         }
 
         return array;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        bool IsArraySpecial(byte ch)
+        {
+            return ch < 128 && (((ch < 64 ? ArraySpecialBitMask0 : ArraySpecialBitMask1) >> ch) & 1) != 0;
+        }
     }
 
     private TomlInlineTable ReadInlineTable()
@@ -2887,10 +2967,10 @@ internal ref struct CsTomlReader
             ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
         if (!TomlCodes.IsNumber(bytes[11])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
         if (!TomlCodes.IsNumber(bytes[12])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
-        if (!TomlCodes.IsColon (bytes[13])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
+        if (!TomlCodes.IsColon(bytes[13])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
         if (!TomlCodes.IsNumber(bytes[14])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
         if (!TomlCodes.IsNumber(bytes[15])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
-        if (!TomlCodes.IsColon (bytes[16])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
+        if (!TomlCodes.IsColon(bytes[16])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
         if (!TomlCodes.IsNumber(bytes[17])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
         if (!TomlCodes.IsNumber(bytes[18])) ExceptionHelper.ThrowIncorrectTomlOffsetDateTimeFormat();
 
@@ -3102,7 +3182,12 @@ internal ref struct CsTomlReader
         }
     }
 
-    private struct TrueMarker { }
-    private struct FalseMarker { }
-}
+    internal struct TrueMarker { }
+    internal struct FalseMarker { }
 
+    private struct TableHeaderMarker { }
+    private struct NotTableHeaderMarker { }
+
+    internal struct ThrowControlCharacterMarker { }
+    internal struct NotThrowControlCharacterMarker { }
+}

--- a/src/CsToml/CsTomlReader.cs
+++ b/src/CsToml/CsTomlReader.cs
@@ -943,7 +943,6 @@ internal ref struct CsTomlReader
                 ExceptionHelper.ThrowInvalidCodePoints();
 
             return nodeHolder.GetKey<T>(bufferWriter.WrittenSpan);
-            //return T.Parse(bufferWriter.WrittenSpan);
         }
         finally
         {
@@ -1179,7 +1178,6 @@ internal ref struct CsTomlReader
         if (fullSpan)
         {
             return nodeHolder.GetKey<T>(unreadSpan[..totalLength]);
-            //return T.Parse(unreadSpan[..totalLength]);
         }
 
         try
@@ -1188,7 +1186,6 @@ internal ref struct CsTomlReader
                 ExceptionHelper.ThrowInvalidCodePoints();
 
             return nodeHolder.GetKey<T>(bufferWriter!.WrittenSpan);
-            //return T.Parse(bufferWriter!.WrittenSpan);
         }
         finally
         {
@@ -1382,12 +1379,10 @@ internal ref struct CsTomlReader
         if (fullSpan)
         {
             return nodeHolder.GetKey<TomlUnquotedDottedKey>(unreadSpan[..totalLength]);
-            //return new TomlUnquotedDottedKey(unreadSpan[..totalLength]);
         }
         try
         {
             return nodeHolder.GetKey<TomlUnquotedDottedKey>(bufferWriter!.WrittenSpan);
-            //return new TomlUnquotedDottedKey(bufferWriter!.WrittenSpan);
         }
         finally
         {

--- a/src/CsToml/Formatter/EnumFormatter.cs
+++ b/src/CsToml/Formatter/EnumFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using CsToml.Error;
 using System.Buffers;
+using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -9,32 +10,42 @@ namespace CsToml.Formatter;
 public sealed class EnumFormatter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum> : ITomlValueFormatter<TEnum>
     where TEnum : Enum
 {
-    private static readonly Dictionary<TEnum, string>? SerializedEnumTable;
-    private static readonly Dictionary<string, TEnum>? DeserializedEnumTable;
-    private static readonly Dictionary<TEnum, string>? SerializedEnumMemberTable;
-    private static readonly Dictionary<string, TEnum>? DeserializedEnumMemberTable;
+    private static readonly FrozenDictionary<TEnum, string>? SerializedEnumTable;
+    private static readonly FrozenDictionary<string, TEnum>? DeserializedEnumTable;
+    private static readonly FrozenDictionary<TEnum, string>? SerializedEnumMemberTable;
+    private static readonly FrozenDictionary<string, TEnum>? DeserializedEnumMemberTable;
 
     static EnumFormatter()
     {
-        SerializedEnumTable = new();
-        DeserializedEnumTable = new();
+        var enumFields = typeof(TEnum).GetFields();
+        var serializedEnumTable = new Dictionary<TEnum, string>(enumFields.Length);
+        var deserializedEnumTable = new Dictionary<string, TEnum>(enumFields.Length);
 
-        foreach(var e in typeof(TEnum).GetFields().Where(x => x.FieldType == typeof(TEnum)))
+        Dictionary<TEnum, string>? serializedEnumMemberTable = null;
+        Dictionary<string, TEnum>? deserializedEnumMemberTable = null;
+
+        foreach (var e in enumFields.AsSpan())
         {
-            var enumValue = (TEnum)e.GetValue(null)!;
-            var enumValueString = e.Name;
-
-            SerializedEnumTable.Add(enumValue, e.Name);
-            DeserializedEnumTable.Add(e.Name, enumValue);
-
-            if (e.GetCustomAttributes().OfType<EnumMemberAttribute>().FirstOrDefault() is { Value: { } enumMember })
+            if (e.FieldType == typeof(TEnum))
             {
-                SerializedEnumMemberTable ??= new();
-                DeserializedEnumMemberTable ??= new();
-                SerializedEnumMemberTable.Add(enumValue, enumMember);
-                DeserializedEnumMemberTable.Add(enumMember, enumValue);
+                var enumValue = (TEnum)e.GetValue(null)!;
+                var enumValueString = e.Name;
+
+                serializedEnumTable.Add(enumValue, e.Name);
+                deserializedEnumTable.Add(e.Name, enumValue);
+
+                if (e.GetCustomAttributes().OfType<EnumMemberAttribute>().FirstOrDefault() is { Value: { } enumMember })
+                {
+                    (serializedEnumMemberTable ??= new()).Add(enumValue, enumMember);
+                    (deserializedEnumMemberTable ??= new()).Add(enumMember, enumValue);
+                }
             }
         }
+
+        SerializedEnumTable = serializedEnumTable.ToFrozenDictionary();
+        DeserializedEnumTable = deserializedEnumTable.ToFrozenDictionary();
+        SerializedEnumMemberTable = serializedEnumMemberTable?.ToFrozenDictionary();
+        DeserializedEnumMemberTable = deserializedEnumMemberTable?.ToFrozenDictionary();
     }
 
     public TEnum Deserialize(ref TomlDocumentNode rootNode, CsTomlSerializerOptions options)

--- a/src/CsToml/Formatter/PrimitiveObjectFormatter.cs
+++ b/src/CsToml/Formatter/PrimitiveObjectFormatter.cs
@@ -2,6 +2,7 @@
 using CsToml.Values;
 using System.Buffers;
 using System.Collections;
+using System.Collections.Frozen;
 using System.Runtime.CompilerServices;
 
 namespace CsToml.Formatter;
@@ -10,7 +11,7 @@ public sealed class PrimitiveObjectFormatter : ITomlValueFormatter<object>
 {
     public static readonly PrimitiveObjectFormatter Instance = new PrimitiveObjectFormatter();
 
-    private static readonly Dictionary<Type, int> TypeToJumpCode = new()
+    private static readonly FrozenDictionary<Type, int> TypeToJumpCode = new Dictionary<Type, int>()
     {
         { typeof(bool), 0 },
         { typeof(byte), 1 },
@@ -29,7 +30,7 @@ public sealed class PrimitiveObjectFormatter : ITomlValueFormatter<object>
         { typeof(DateTimeOffset), 14 },
         { typeof(DateOnly), 15 },
         { typeof(TimeOnly), 16 },
-    };
+    }.ToFrozenDictionary();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetJumpCode(Type type, out int jumpCode)

--- a/src/CsToml/TomlDocument.cs
+++ b/src/CsToml/TomlDocument.cs
@@ -54,6 +54,15 @@ public partial class TomlDocument : ITomlValueFormatter<TomlDocument>
         TomlTableNode currentNode = table.RootNode;
         TomlTableNode commentNode = table.RootNode;
 
+        TomlTableNodeHolder nodeHolder = default;
+
+        // Key-reuse sources: keys repeat because same-schema tables repeat, so the
+        // previously completed sibling table (mirror) already holds identical key instances.
+        TomlTableNode? tableKeyMirror = null;
+        TomlTableNode? previousTableNode = null;
+        TomlTableNode? aotPreviousElementRoot = null;
+        TomlTableNode? aotCurrentElementRoot = null;
+
         var parser = new CsTomlParser(ref reader, options);
         currentNode.ReserveNodeCapacity(parser.reader.EstimateDirectKeyCount());
 
@@ -77,11 +86,13 @@ public partial class TomlDocument : ITomlValueFormatter<TomlDocument>
 
                     case ParserState.KeyValue:
                         var node = currentNode;
-                        var readResult = parser.reader.ReadKey(true, out var key);
+                        nodeHolder.node = tableKeyMirror;
+                        var readResult = parser.reader.ReadKey(true, nodeHolder, out var key);
                         while (readResult == ReadKeyResult.FoundDot)
                         {
                             node = node.GetOrAddKeyNode(key!);
-                            readResult = parser.reader.ReadKey(false, out key);
+                            nodeHolder.node = nodeHolder.node?.TryGetMirrorChild(key!);
+                            readResult = parser.reader.ReadKey(false, nodeHolder, out key);
                         }
 
                         var value = parser.reader.ReadValue();
@@ -91,28 +102,39 @@ public partial class TomlDocument : ITomlValueFormatter<TomlDocument>
 
                     case ParserState.TableHeader:
                         currentNode = table.RootNode;
-                        var readTableHeaderResult = parser.reader.ReadTableHeaderKey(true, out var tableHeaderKey);
+                        nodeHolder.node = currentNode;
+                        var readTableHeaderResult = parser.reader.ReadTableHeaderKey(true, nodeHolder, out var tableHeaderKey);
+                        var tableMirror = default(TomlTableNode);
                         while (readTableHeaderResult == ReadKeyResult.FoundDot)
                         {
                             currentNode = currentNode.GetOrAddTableHeaderKeyNode(tableHeaderKey!, out bool newNode);
-                            readTableHeaderResult = parser.reader.ReadTableHeaderKey(false, out tableHeaderKey);
+                            tableMirror = currentNode == aotCurrentElementRoot ? aotPreviousElementRoot : tableMirror?.TryGetMirrorChild(tableHeaderKey!);
+                            nodeHolder.node = currentNode;
+                            readTableHeaderResult = parser.reader.ReadTableHeaderKey(false, nodeHolder, out tableHeaderKey);
                         }
 
                         currentNode = currentNode.AddTableHeaderKeyLastNode(tableHeaderKey!);
                         currentNode.ReserveNodeCapacity(parser.reader.EstimateDirectKeyCount());
+                        tableKeyMirror = tableMirror?.TryGetMirrorChild(tableHeaderKey!) ?? previousTableNode;
+                        previousTableNode = currentNode;
                         commentNode = currentNode;
                         break;
 
                     case ParserState.ArrayOfTablesHeader:
                         currentNode = table.RootNode;
-                        var readArrayOfTableHeaderResult = parser.reader.ReadArrayOfTableHeaderKey(true, out var arrayOfTableHeaderKey);
+                        nodeHolder.node = currentNode;
+                        var readArrayOfTableHeaderResult = parser.reader.ReadArrayOfTableHeaderKey(true, nodeHolder, out var arrayOfTableHeaderKey);
                         while (readArrayOfTableHeaderResult == ReadKeyResult.FoundDot)
                         {
                             currentNode = currentNode.GetOrAddArrayOfTableHeaderKeyNode(arrayOfTableHeaderKey!, false, out bool newNode);
-                            readArrayOfTableHeaderResult = parser.reader.ReadArrayOfTableHeaderKey(false, out arrayOfTableHeaderKey);
+                            nodeHolder.node = currentNode;
+                            readArrayOfTableHeaderResult = parser.reader.ReadArrayOfTableHeaderKey(false, nodeHolder, out arrayOfTableHeaderKey);
                         }
-                        currentNode = currentNode.AddArrayOfTableHeaderKeyLastNode(arrayOfTableHeaderKey!, out commentNode);
+                        currentNode = currentNode.AddArrayOfTableHeaderKeyLastNode(arrayOfTableHeaderKey!, out commentNode, out aotPreviousElementRoot);
                         currentNode.ReserveNodeCapacity(parser.reader.EstimateDirectKeyCount());
+                        aotCurrentElementRoot = currentNode;
+                        tableKeyMirror = aotPreviousElementRoot;
+                        previousTableNode = currentNode;
                         break;
 
                     case ParserState.ThrowException:

--- a/src/CsToml/TomlDocument.cs
+++ b/src/CsToml/TomlDocument.cs
@@ -55,6 +55,7 @@ public partial class TomlDocument : ITomlValueFormatter<TomlDocument>
         TomlTableNode commentNode = table.RootNode;
 
         var parser = new CsTomlParser(ref reader, options);
+        currentNode.ReserveNodeCapacity(parser.reader.EstimateDirectKeyCount());
 
         while (parser.Read())
         {
@@ -98,6 +99,7 @@ public partial class TomlDocument : ITomlValueFormatter<TomlDocument>
                         }
 
                         currentNode = currentNode.AddTableHeaderKeyLastNode(tableHeaderKey!);
+                        currentNode.ReserveNodeCapacity(parser.reader.EstimateDirectKeyCount());
                         commentNode = currentNode;
                         break;
 
@@ -110,6 +112,7 @@ public partial class TomlDocument : ITomlValueFormatter<TomlDocument>
                             readArrayOfTableHeaderResult = parser.reader.ReadArrayOfTableHeaderKey(false, out arrayOfTableHeaderKey);
                         }
                         currentNode = currentNode.AddArrayOfTableHeaderKeyLastNode(arrayOfTableHeaderKey!, out commentNode);
+                        currentNode.ReserveNodeCapacity(parser.reader.EstimateDirectKeyCount());
                         break;
 
                     case ParserState.ThrowException:

--- a/src/CsToml/Values/TomlDottedKey.cs
+++ b/src/CsToml/Values/TomlDottedKey.cs
@@ -1,5 +1,4 @@
-﻿using CsToml.Error;
-using CsToml.Utility;
+﻿using CsToml.Utility;
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/CsToml/Values/TomlTable.GetValue.cs
+++ b/src/CsToml/Values/TomlTable.GetValue.cs
@@ -1,6 +1,4 @@
 ﻿
-using CsToml.Error;
-
 namespace CsToml.Values;
 
 internal partial class TomlTable 

--- a/src/CsToml/Values/TomlTableNode.cs
+++ b/src/CsToml/Values/TomlTableNode.cs
@@ -145,6 +145,25 @@ internal sealed class TomlTableNode
         return CollectionsMarshal.AsSpan(this.comments).Slice(count, commentCount);
     }
 
+    internal bool TryGetKey(ReadOnlySpan<byte> key, out TomlDottedKey? dottedKey)
+    {
+        dottedKey = null;
+        return nodes?.TryGetKey(key, out dottedKey) ?? false;
+    }
+
+    internal TomlTableNode? TryGetMirrorChild(TomlDottedKey key)
+    {
+        if (nodes == null || !nodes.TryGetValue(key, out var child))
+        {
+            return null;
+        }
+        if (child!.IsArrayOfTablesHeaderDefinitionPosition)
+        {
+            return ((child.Value as TomlArray)?.LastValue as TomlTable)?.RootNode;
+        }
+        return child;
+    }
+
     internal TomlTableNode GetOrAddArrayOfTableHeaderKeyNode(TomlDottedKey key, bool lastNode, out bool newNode)
     {
         newNode = false;
@@ -178,7 +197,7 @@ internal sealed class TomlTableNode
         return default;
     }
 
-    internal TomlTableNode AddArrayOfTableHeaderKeyLastNode(TomlDottedKey key, out TomlTableNode commentNode)
+    internal TomlTableNode AddArrayOfTableHeaderKeyLastNode(TomlDottedKey key, out TomlTableNode commentNode, out TomlTableNode? previousTableRootNode)
     {
         var node = GetOrAddArrayOfTableHeaderKeyNode(key, true, out var newNode);
 
@@ -200,12 +219,13 @@ internal sealed class TomlTableNode
                 ExceptionHelper.ThrowTheArrayOfTablesIsDefinedAsTable(key.ToString());
             }
         }
+        var array = node.Value as TomlArray;
+        previousTableRootNode = (array?.LastValue as TomlTable)?.RootNode;
         var table = new TomlTable();
-        (node.Value as TomlArray)?.Add(table);
+        array?.Add(table);
         commentNode = node;
         return table.RootNode;
     }
-
 
     internal TomlTableNode GetOrAddTableHeaderKeyNode(TomlDottedKey key, out bool newNode)
     {

--- a/src/CsToml/Values/TomlTableNode.cs
+++ b/src/CsToml/Values/TomlTableNode.cs
@@ -134,6 +134,10 @@ internal sealed class TomlTableNode
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void ReserveNodeCapacity(int estimatedCount)
+        => nodes?.EnsureCapacity(estimatedCount);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal Span<TomlString> SetCommentCount(int commentCount)
     {
         var count = (this.comments ??= new List<TomlString>(commentCount)).Count;

--- a/src/CsToml/Values/TomlTableNodeDictionary.cs
+++ b/src/CsToml/Values/TomlTableNodeDictionary.cs
@@ -51,7 +51,7 @@ internal sealed class TomlTableNodeDictionary
     private const int MaxInitialCapacity = 1103;
 
     // Used when the estimate saturates MaxInitialCapacity: such a table will keep growing
-    // past the initial allocation, so it must start on the default Reserve chai.
+    // past the initial allocation, so it must start on the default Reserve chain.
     // An off-chain start such as 1103 strands large tables on the 1103→2333→4861→10103 chain.
     private const int SaturatedInitialCapacity = 919;
 

--- a/src/CsToml/Values/TomlTableNodeDictionary.cs
+++ b/src/CsToml/Values/TomlTableNodeDictionary.cs
@@ -45,6 +45,33 @@ internal sealed class TomlTableNodeDictionary
         entries = [];
     }
 
+    // Largest initial capacity EnsureCapacity may allocate. Keeps a wildly overestimated
+    // hint (e.g. '=' bytes inside huge strings) from over-allocating; larger tables
+    // simply grow through Reserve as before.
+    private const int MaxInitialCapacity = 1103;
+
+    // Used when the estimate saturates MaxInitialCapacity: such a table will keep growing
+    // past the initial allocation, so it must start on the default Reserve chai.
+    // An off-chain start such as 1103 strands large tables on the 1103→2333→4861→10103 chain.
+    private const int SaturatedInitialCapacity = 919;
+
+    // Pre-sizes the backing arrays from an estimated entry count so that parsing can skip
+    // intermediate Reserve (rehash) steps. Applies only to a dictionary with no allocated
+    // buckets; estimates are best-effort and never affect correctness.
+    public void EnsureCapacity(int estimatedCount)
+    {
+        if (buckets.Length != 0 || estimatedCount <= 0)
+        {
+            return;
+        }
+
+        var capacity = estimatedCount <= MaxInitialCapacity
+            ? HashHelpers.GetPrime(estimatedCount)
+            : SaturatedInitialCapacity;
+        entries = new Entry[capacity];
+        buckets = new int[capacity];
+    }
+
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryAdd(TomlDottedKey key, TomlTableNode value)

--- a/src/CsToml/Values/TomlTableNodeDictionary.cs
+++ b/src/CsToml/Values/TomlTableNodeDictionary.cs
@@ -175,18 +175,24 @@ internal sealed class TomlTableNodeDictionary
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetValue(TomlDottedKey key, out TomlTableNode? value)
-        => TryGetValueCore(key.Value, key.GetHashCodeFast(), out value);
+        => TryGetValueCore(key.Value, key.GetHashCodeFast(), out _, out value);
 
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetValue(ReadOnlySpan<byte> key, out TomlTableNode? value)
-        => TryGetValueCore(key, ByteArrayHash.ToInt32(key), out value);
+        => TryGetValueCore(key, ByteArrayHash.ToInt32(key), out _, out value);
 
-    private bool TryGetValueCore(ReadOnlySpan<byte> key, int hashCode, out TomlTableNode? value)
+    [DebuggerStepThrough]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetKey(ReadOnlySpan<byte> key, out TomlDottedKey? dottedKey)
+        => TryGetValueCore(key, ByteArrayHash.ToInt32(key), out dottedKey, out _);
+
+    private bool TryGetValueCore(ReadOnlySpan<byte> key, int hashCode, out TomlDottedKey? dottedKey, out TomlTableNode? value)
     {
         var buckets = this.buckets;
         if (buckets.Length == 0)
         {
+            dottedKey = null;
             value = null;
             return false;
         }
@@ -200,6 +206,7 @@ internal sealed class TomlTableNodeDictionary
         {
             if ((uint)index > (uint)entries.Length)
             {
+                dottedKey = null;
                 value = null;
                 return false;
             }
@@ -207,6 +214,7 @@ internal sealed class TomlTableNodeDictionary
             ref var e = ref entries[index];
             if (e.hashCode == hashCode && e.key.Equals(key))
             {
+                dottedKey = e.key;
                 value = e.value;
                 return true;
             }
@@ -215,6 +223,7 @@ internal sealed class TomlTableNodeDictionary
         }
         while (++conflictCount <= (uint)buckets.Length);
 
+        dottedKey = null;
         value = null;
         return false;
     }

--- a/src/CsToml/Values/TomlTableNodeHolder.cs
+++ b/src/CsToml/Values/TomlTableNodeHolder.cs
@@ -1,0 +1,25 @@
+﻿
+namespace CsToml.Values;
+
+internal ref struct TomlTableNodeHolder
+{
+    public TomlTableNode? node;
+
+    public T GetKey<T>(ReadOnlySpan<byte> key)
+        where T : TomlValue, ITomlStringParser<T>
+    {
+        if (node == null)
+        {
+            return T.Parse(key);
+        }
+
+        // Use TomlDottedKey from TomlTableNode if the key is already parsed and stored in the node.
+        if (node.TryGetKey(key, out var dottedKey) && dottedKey is T typedDottedKey)
+        {
+            return typedDottedKey!;
+        }
+
+        return T.Parse(key);
+    }
+
+}

--- a/src/CsToml/Values/TomlTableNodeHolder.cs
+++ b/src/CsToml/Values/TomlTableNodeHolder.cs
@@ -3,7 +3,7 @@ namespace CsToml.Values;
 
 internal ref struct TomlTableNodeHolder
 {
-    public TomlTableNode? node;
+    internal TomlTableNode? node;
 
     public T GetKey<T>(ReadOnlySpan<byte> key)
         where T : TomlValue, ITomlStringParser<T>

--- a/tests/CsToml.Tests/ArrayReadMultiSegmentTest.cs
+++ b/tests/CsToml.Tests/ArrayReadMultiSegmentTest.cs
@@ -1,0 +1,161 @@
+﻿using CsToml.Error;
+using CsToml.Utility;
+using System.Buffers;
+
+namespace CsToml.Tests;
+
+public class ArrayReadMultiSegmentTest
+{
+    private static ReadOnlySequence<byte> CreateSequence(params byte[][] chunks)
+    {
+        var first = new ByteSequenceSegment(chunks[0]);
+        var last = first;
+        for (var i = 1; i < chunks.Length; i++)
+        {
+            last = last.AddNext(chunks[i]);
+        }
+        return new ReadOnlySequence<byte>(first, 0, last, last.Length);
+    }
+
+    private static TomlDocument DeserializeAndCompare(params byte[][] chunks)
+    {
+        var whole = chunks.SelectMany(c => c).ToArray();
+        var singleSegment = CsTomlSerializer.Deserialize<TomlDocument>(whole);
+        var multiSegment = CsTomlSerializer.Deserialize<TomlDocument>(CreateSequence(chunks));
+        multiSegment.LineNumber.ShouldBe(singleSegment.LineNumber);
+        return multiSegment;
+    }
+
+    [Fact]
+    public void Elements_SplitAcrossTwoSegments()
+    {
+        var document = DeserializeAndCompare(
+            "value = [ 1, 2"u8.ToArray(),
+            ", 3 ]"u8.ToArray());
+
+        document.RootNode["value"u8][0].GetInt64().ShouldBe(1);
+        document.RootNode["value"u8][1].GetInt64().ShouldBe(2);
+        document.RootNode["value"u8][2].GetInt64().ShouldBe(3);
+    }
+
+    [Fact]
+    public void DelimiterRun_ExhaustsSegment()
+    {
+        // The first segment ends inside a run of spaces, driving the
+        // Advance(unreadSpan.Length) segment-exhausted path.
+        var document = DeserializeAndCompare(
+            "value = [ 1,   "u8.ToArray(),
+            "   2 ]"u8.ToArray());
+
+        document.RootNode["value"u8][0].GetInt64().ShouldBe(1);
+        document.RootNode["value"u8][1].GetInt64().ShouldBe(2);
+    }
+
+    [Fact]
+    public void ClosingBracket_IsFirstByteOfNextSegment()
+    {
+        var document = DeserializeAndCompare(
+            "value = [ 1, 2 "u8.ToArray(),
+            "]"u8.ToArray());
+
+        document.RootNode["value"u8][1].GetInt64().ShouldBe(2);
+    }
+
+    [Fact]
+    public void ValueStart_IsFirstByteOfNextSegment()
+    {
+        var document = DeserializeAndCompare(
+            "value = [ 1, "u8.ToArray(),
+            "22 ]"u8.ToArray());
+
+        document.RootNode["value"u8][1].GetInt64().ShouldBe(22);
+    }
+
+    [Fact]
+    public void LineFeed_IsLastByteOfSegment()
+    {
+        // LF as the final byte of a segment drives the Advance + IncreaseLineNumber sync path.
+        var document = DeserializeAndCompare(
+            "value = [ 1,\n"u8.ToArray(),
+            "2 ]\nafter = 3"u8.ToArray());
+
+        document.RootNode["value"u8][1].GetInt64().ShouldBe(2);
+        document.RootNode["after"u8].GetInt64().ShouldBe(3);
+        document.LineNumber.ShouldBe(3);
+    }
+
+    [Fact]
+    public void MultilineArray_CountsLines_SingleSegmentEquivalence()
+    {
+        var document = DeserializeAndCompare(
+            "value = [\n  1,\n  2,\n"u8.ToArray(),
+            "  3,\n]\nafter = 4"u8.ToArray());
+
+        document.RootNode["value"u8][2].GetInt64().ShouldBe(3);
+        document.RootNode["after"u8].GetInt64().ShouldBe(4);
+        document.LineNumber.ShouldBe(6);
+    }
+
+    [Fact]
+    public void CrLf_SplitAcrossSegments()
+    {
+        // CR as the final byte of a segment drives the reader-synced CR fallback.
+        var document = DeserializeAndCompare(
+            "value = [ 1,\r"u8.ToArray(),
+            "\n2 ]"u8.ToArray());
+
+        document.RootNode["value"u8][1].GetInt64().ShouldBe(2);
+    }
+
+    [Fact]
+    public void NestedArray_AtSegmentBoundary()
+    {
+        var document = DeserializeAndCompare(
+            "value = [ [ 1, 2 ], "u8.ToArray(),
+            "[ 3 ] ]"u8.ToArray());
+
+        document.RootNode["value"u8][0][1].GetInt64().ShouldBe(2);
+        document.RootNode["value"u8][1][0].GetInt64().ShouldBe(3);
+    }
+
+    [Fact]
+    public void CommentInsideArray_SplitAcrossSegments()
+    {
+        var document = DeserializeAndCompare(
+            "value = [ 1, # com"u8.ToArray(),
+            "ment\n2 ]"u8.ToArray());
+
+        document.RootNode["value"u8][0].GetInt64().ShouldBe(1);
+        document.RootNode["value"u8][1].GetInt64().ShouldBe(2);
+    }
+
+    [Fact]
+    public void TrailingComma_BeforeSegmentBoundary()
+    {
+        var document = DeserializeAndCompare(
+            "value = [ 1, 2,"u8.ToArray(),
+            " ]"u8.ToArray());
+
+        document.RootNode["value"u8][1].GetInt64().ShouldBe(2);
+    }
+
+    [Fact]
+    public void DoubleComma_AcrossSegments_Throws()
+    {
+        var sequence = CreateSequence(
+            "value = [ 1,"u8.ToArray(),
+            ", 2 ]"u8.ToArray());
+
+        Should.Throw<CsTomlSerializeException>(() => CsTomlSerializer.Deserialize<TomlDocument>(sequence));
+    }
+
+    [Fact]
+    public void UnclosedArray_EndsAtSegmentBoundary_Throws()
+    {
+        var sequence = CreateSequence(
+            "value = [ 1, "u8.ToArray(),
+            "2 "u8.ToArray());
+
+        Should.Throw<CsTomlSerializeException>(() => CsTomlSerializer.Deserialize<TomlDocument>(sequence));
+    }
+}


### PR DESCRIPTION
This PR optimize TOML parsing in `CsTomlSerializer.Deserialize<TomlDocument>`. 
This Change reduces memory allocation in main/common use cases.

## Changed
- Estimate the initial capacity of  `TomlTableNodeDictionary` from key/value pairs
- Reuse duplicated  `TomlDottedKey` in  `TomlTableNode`
- Change from switch processing to custom bitMask(`ulong`) in `ReadUnquotedString`/`ReadArray`

## Benchmark

| Method                 | Job                | BuildConfiguration | Toolchain | Mean      | Error     | StdDev    | Gen0    | Gen1   | Allocated |
|----------------------- |------------------- |------------------- |---------- |----------:|----------:|----------:|--------:|-------:|----------:|
| CsToml_Parse_FromUTF16 | Benchmark.NET 10.0 | Default            | .NET 10.0 |  28.34 us |  1.191 us |  1.782 us |  3.6926 | 0.3357 |  30.41 KB |
| CsToml_Parse_FromUTF8  | Benchmark.NET 10.0 | Default            | .NET 10.0 |  23.35 us |  1.406 us |  1.925 us |  3.2959 | 0.3052 |  26.99 KB |
| Tommy_Parse            | Benchmark.NET 10.0 | Default            | .NET 10.0 |  78.13 us |  3.639 us |  5.334 us | 11.4746 | 0.9766 |  93.81 KB |
| Tomlet_Parse           | Benchmark.NET 10.0 | Default            | .NET 10.0 | 547.19 us | 30.420 us | 44.590 us | 33.2031 | 2.9297 | 273.86 KB |
| Tomlyn_Parse           | Benchmark.NET 10.0 | Default            | .NET 10.0 | 163.38 us |  8.868 us | 13.273 us |  3.4180 | 0.2441 |   29.6 KB |
| CsToml_Parse_FromUTF16 | Benchmark.NET 8.0  | Default            | .NET 8.0  |  35.69 us |  2.352 us |  3.447 us |  3.6621 | 0.3052 |  30.41 KB |
| CsToml_Parse_FromUTF8  | Benchmark.NET 8.0  | Default            | .NET 8.0  |  30.83 us |  1.647 us |  2.414 us |  3.2959 | 0.3052 |  26.99 KB |
| Tommy_Parse            | Benchmark.NET 8.0  | Default            | .NET 8.0  |  92.53 us |  4.266 us |  6.252 us | 11.4746 | 0.9766 |  94.19 KB |
| Tomlet_Parse           | Benchmark.NET 8.0  | Default            | .NET 8.0  | 695.67 us | 46.870 us | 70.152 us | 34.1797 | 2.9297 | 285.36 KB |
| Tomlyn_Parse           | Benchmark.NET 8.0  | Default            | .NET 8.0  | 190.40 us | 13.238 us | 19.404 us |  2.9297 |      - |   29.6 KB |
| CsToml_Parse_FromUTF16 | Benchmark.NET 9.0  | Default            | .NET 9.0  |  30.00 us |  2.265 us |  3.390 us |  3.6926 | 0.3357 |  30.41 KB |
| CsToml_Parse_FromUTF8  | Benchmark.NET 9.0  | Default            | .NET 9.0  |  27.92 us |  1.345 us |  1.972 us |  3.2959 | 0.3052 |  26.99 KB |
| Tommy_Parse            | Benchmark.NET 9.0  | Default            | .NET 9.0  |  87.03 us |  3.581 us |  5.360 us | 11.4746 | 0.9766 |  94.19 KB |
| Tomlet_Parse           | Benchmark.NET 9.0  | Default            | .NET 9.0  | 617.88 us | 20.606 us | 29.552 us | 34.1797 | 2.9297 | 285.34 KB |
| Tomlyn_Parse           | Benchmark.NET 9.0  | Default            | .NET 9.0  | 167.09 us |  7.494 us | 10.985 us |  3.4180 | 0.2441 |   29.6 KB |
| CsToml_Parse_FromUTF16 | NuGetCsToml        | NuGetCsToml        | .NET 10.0 |  31.13 us |  2.442 us |  3.503 us |  3.9978 | 0.3967 |  32.71 KB |
| CsToml_Parse_FromUTF8  | NuGetCsToml        | NuGetCsToml        | .NET 10.0 |  29.89 us |  1.962 us |  2.937 us |  3.5706 | 0.3357 |   29.3 KB |
| Tommy_Parse            | NuGetCsToml        | NuGetCsToml        | .NET 10.0 |  98.27 us |  5.933 us |  8.697 us | 11.4746 | 0.9766 |  93.81 KB |
| Tomlet_Parse           | NuGetCsToml        | NuGetCsToml        | .NET 10.0 | 587.74 us | 42.267 us | 63.263 us | 33.2031 | 2.9297 | 273.86 KB |
| Tomlyn_Parse           | NuGetCsToml        | NuGetCsToml        | .NET 10.0 | 159.71 us |  8.261 us | 12.108 us |  2.9297 |      - |   29.6 KB |