### PR TITLE
Changes to the conversion logic for decimal from floating-point

### DIFF
--- a/src/CsToml/Formatter/DecimalFormatter.cs
+++ b/src/CsToml/Formatter/DecimalFormatter.cs
@@ -49,12 +49,12 @@ internal sealed class DecimalFormatter : ITomlValueFormatter<decimal>
         }
 
         Span<byte> utf8 = stackalloc byte[32];
-        doubleValue.TryFormat(utf8, out var bytesWritten, default, CultureInfo.InvariantCulture);
-        if (Utf8Parser.TryParse(utf8.Slice(0, bytesWritten), out decimal value, out var bytesConsumed, 'G') && bytesConsumed == bytesWritten)
+        if (doubleValue.TryFormat(utf8, out var bytesWritten, "G", CultureInfo.InvariantCulture) &&
+            Utf8Parser.TryParse(utf8.Slice(0, bytesWritten), out decimal value, out var bytesConsumed, 'G') &&
+            bytesConsumed == bytesWritten)
         {
             return value;
         }
-
         return (decimal)doubleValue;
     }
 

--- a/src/CsToml/Formatter/DecimalFormatter.cs
+++ b/src/CsToml/Formatter/DecimalFormatter.cs
@@ -1,5 +1,8 @@
 ﻿using CsToml.Error;
+using CsToml.Values;
 using System.Buffers;
+using System.Buffers.Text;
+using System.Globalization;
 
 namespace CsToml.Formatter;
 
@@ -14,13 +17,45 @@ internal sealed class DecimalFormatter : ITomlValueFormatter<decimal>
             return default!;
         }
 
-        if (rootNode.TryGetDouble(out var doubleValue))
+        if (rootNode.HasValueOnly)
         {
-            return (decimal)doubleValue;
+            // If toml value is an integer, get it as Int64 to avoid precision loss when converting from double to decimal
+            var rawTomlValue = rootNode.Value;
+            if (rawTomlValue.Type == TomlValueType.Integer)
+            {
+                return rawTomlValue.GetInt64();
+            }
+
+            if (rawTomlValue.TryGetDouble(out var doubleValue))
+            {
+                return ConvertToDecimal(doubleValue);
+            }
         }
 
         ExceptionHelper.ThrowDeserializationFailed(typeof(decimal));
         return default;
+    }
+
+    internal static decimal ConvertToDecimal(double doubleValue)
+    {
+        // The (decimal)double cast rounding changed in .NET 11 (.NET 11 preview 7).
+        // [dotnet/runtime PR]: https://github.com/dotnet/runtime/pull/130566
+        // Parse the shortest round-trippable representation instead of casting, so the result keeps
+        // the decimal digits written in the TOML text (e.g. 3.14 -> 3.14m) on all runtime versions.
+
+        if (!double.IsFinite(doubleValue))
+        {
+            return (decimal)doubleValue;
+        }
+
+        Span<byte> utf8 = stackalloc byte[32];
+        doubleValue.TryFormat(utf8, out var bytesWritten, default, CultureInfo.InvariantCulture);
+        if (Utf8Parser.TryParse(utf8.Slice(0, bytesWritten), out decimal value, out var bytesConsumed, 'G') && bytesConsumed == bytesWritten)
+        {
+            return value;
+        }
+
+        return (decimal)doubleValue;
     }
 
     public void Serialize<TBufferWriter>(ref Utf8TomlDocumentWriter<TBufferWriter> writer, decimal target, CsTomlSerializerOptions options)
@@ -38,9 +73,19 @@ internal sealed class NullableDecimalFormatter : ITomlValueFormatter<decimal?>
     {
         if (!rootNode.HasValue) return default;
 
-        if (rootNode.TryGetDouble(out var doubleValue))
+        if (rootNode.HasValueOnly)
         {
-            return (decimal)doubleValue;
+            // If toml value is an integer, get it as Int64 to avoid precision loss when converting from double to decimal
+            var rawTomlValue = rootNode.Value;
+            if (rawTomlValue.Type == TomlValueType.Integer)
+            {
+                return rawTomlValue.GetInt64();
+            }
+
+            if (rawTomlValue.TryGetDouble(out var doubleValue))
+            {
+                return DecimalFormatter.ConvertToDecimal(doubleValue);
+            }
         }
 
         return null;

--- a/tests/CsToml.Generator.Tests/Generator/TypeDecimalTest.cs
+++ b/tests/CsToml.Generator.Tests/Generator/TypeDecimalTest.cs
@@ -1,4 +1,4 @@
-using Shouldly;
+﻿using Shouldly;
 using Utf8StringInterpolation;
 
 namespace CsToml.Generator.Tests;
@@ -61,8 +61,8 @@ public class TypeDecimalTest
         writer.Flush();
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        result.FloatValue.ShouldBe((decimal)3.14);
-        result.NegativeValue.ShouldBe((decimal)(-123.456));
+        result.FloatValue.ShouldBe(3.14m);
+        result.NegativeValue.ShouldBe(-123.456m);
         result.ZeroValue.ShouldBe(0m);
     }
 
@@ -80,7 +80,7 @@ public class TypeDecimalTest
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
         result.NullableIntegerValue.ShouldBe(42m);
-        result.NullableFloatValue.ShouldBe((decimal)1.5);
+        result.NullableFloatValue.ShouldBe(1.5m);
     }
 
     [Fact]
@@ -100,9 +100,11 @@ public class TypeDecimalTest
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(bytes.ByteSpan);
 
         result.IntegerValue.ShouldBe(original.IntegerValue);
+        result.FloatValue.ShouldBe(original.FloatValue);
         result.NegativeValue.ShouldBe(original.NegativeValue);
         result.ZeroValue.ShouldBe(original.ZeroValue);
         result.NullableIntegerValue.ShouldBe(original.NullableIntegerValue);
+        result.NullableFloatValue.ShouldBe(original.NullableFloatValue);
     }
 
     // --- Edge Cases: Integer Boundaries ---
@@ -118,8 +120,8 @@ public class TypeDecimalTest
         writer.Flush();
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        // double cannot represent long.MaxValue exactly (> 2^53), so precision loss occurs
-        result.IntegerValue.ShouldBe((decimal)(double)long.MaxValue);
+        // TOML integers are read as Int64 and converted to decimal without precision loss
+        result.IntegerValue.ShouldBe(9223372036854775807m);
     }
 
     [Fact]
@@ -133,7 +135,7 @@ public class TypeDecimalTest
         writer.Flush();
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        result.IntegerValue.ShouldBe((decimal)(double)long.MinValue);
+        result.IntegerValue.ShouldBe(-9223372036854775808m);
     }
 
     [Fact]
@@ -152,8 +154,6 @@ public class TypeDecimalTest
         result.ZeroValue.ShouldBe(0m);
     }
 
-    // --- Edge Cases: Float Format Variations (ABNF: exp / frac [ exp ]) ---
-
     [Fact]
     public void DeserializeFromFloat_ExponentOnly()
     {
@@ -165,8 +165,8 @@ public class TypeDecimalTest
         writer.Flush();
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        result.IntegerValue.ShouldBe((decimal)1e10);
-        result.FloatValue.ShouldBe((decimal)(-2E-2));
+        result.IntegerValue.ShouldBe(1e10m);
+        result.FloatValue.ShouldBe(-2E-2m);
     }
 
     [Fact]
@@ -181,7 +181,7 @@ public class TypeDecimalTest
         writer.Flush();
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        result.IntegerValue.ShouldBe((decimal)1e6);
+        result.IntegerValue.ShouldBe(1e6m);
     }
 
     [Fact]
@@ -195,9 +195,9 @@ public class TypeDecimalTest
         writer.Flush();
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        result.IntegerValue.ShouldBe((decimal)6.626e-34);
-        result.FloatValue.ShouldBe((decimal)1.0e+2);
-        result.NegativeValue.ShouldBe((decimal)(-1.23e4));
+        result.IntegerValue.ShouldBe(0m); // underflows the decimal range
+        result.FloatValue.ShouldBe(1.0e+2m);
+        result.NegativeValue.ShouldBe(-1.23e4m);
     }
 
     [Fact]
@@ -213,7 +213,7 @@ public class TypeDecimalTest
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
         result.IntegerValue.ShouldBe(1.0m);
-        result.NegativeValue.ShouldBe((decimal)(-0.01));
+        result.NegativeValue.ShouldBe(-0.01m);
     }
 
     [Fact]
@@ -228,10 +228,8 @@ public class TypeDecimalTest
         writer.Flush();
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        result.IntegerValue.ShouldBe((decimal)224617.445991228);
+        result.IntegerValue.ShouldBe(224617.445991228m);
     }
-
-    // --- Edge Cases: Special Float Values (ABNF: special-float) ---
 
     [Fact]
     public void DeserializeFromFloat_Inf_ThrowsOverflowException()
@@ -320,8 +318,6 @@ public class TypeDecimalTest
             CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
     }
 
-    // --- Edge Cases: Float Boundary Values ---
-
     [Fact]
     public void DeserializeFromFloat_SmallValue()
     {
@@ -333,7 +329,7 @@ public class TypeDecimalTest
         writer.Flush();
 
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        result.IntegerValue.ShouldBe((decimal)1e-28);
+        result.IntegerValue.ShouldBe(1e-28m);
         result.FloatValue.ShouldBe(0m);
         result.NegativeValue.ShouldBe(0m); // -0.0 as double → decimal becomes 0
     }
@@ -366,7 +362,7 @@ public class TypeDecimalTest
 
         // 5e+22 fits in decimal range, should succeed
         var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
-        result.IntegerValue.ShouldBe((decimal)5e+22);
+        result.IntegerValue.ShouldBe(5e+22m);
     }
 
     [Fact]
@@ -383,8 +379,6 @@ public class TypeDecimalTest
         Should.Throw<OverflowException>(() =>
             CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
     }
-
-    // --- Edge Cases: Serialize Boundary Values ---
 
     [Fact]
     public void Serialize_DecimalMaxValue()
@@ -440,5 +434,110 @@ public class TypeDecimalTest
 
         var expected = buffer.ToArray();
         bytes.ByteSpan.ToArray().ShouldBe(expected);
+    }
+
+    [Fact]
+    public void DeserializeFromFloat_KeepsShortestRoundTripDigits()
+    {
+        // These need 16-17 significant digits, which a (decimal)double cast would have rounded away.
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 9223372036854775808.0");
+        writer.AppendLine("FloatValue = 0.30000000000000004");
+        writer.AppendLine("NegativeValue = -1.2345678901234567e+25");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.IntegerValue.ShouldBe(9223372036854776000m);
+        result.FloatValue.ShouldBe(0.30000000000000004m);
+        result.NegativeValue.ShouldBe(-12345678901234566000000000m);
+    }
+
+    [Fact]
+    public void DeserializeNullable_FromLongBoundaries()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 0");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.AppendLine("NullableIntegerValue = 9223372036854775807");
+        writer.AppendLine("NullableFloatValue = -9223372036854775808");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.NullableIntegerValue.ShouldBe(9223372036854775807m);
+        result.NullableFloatValue.ShouldBe(-9223372036854775808m);
+    }
+
+    [Fact]
+    public void DeserializeNullable_ProducesSameValueAsNonNullable()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 9223372036854775807");
+        writer.AppendLine("FloatValue = 0.30000000000000004");
+        writer.AppendLine("NegativeValue = -123.456");
+        writer.AppendLine("ZeroValue = 0");
+        writer.AppendLine("NullableIntegerValue = 9223372036854775807");
+        writer.AppendLine("NullableFloatValue = 0.30000000000000004");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.NullableIntegerValue.ShouldBe(result.IntegerValue);
+        result.NullableFloatValue.ShouldBe(result.FloatValue);
+    }
+
+    [Fact]
+    public void DeserializeNullable_MissingKey_ReturnsNull()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 0");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.Flush();
+
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan);
+        result.NullableIntegerValue.ShouldBeNull();
+        result.NullableFloatValue.ShouldBeNull();
+    }
+
+    [Fact]
+    public void DeserializeNullable_FromInf_ThrowsOverflowException()
+    {
+        using var buffer = Utf8String.CreateWriter(out var writer);
+        writer.AppendLine("IntegerValue = 0");
+        writer.AppendLine("FloatValue = 0");
+        writer.AppendLine("NegativeValue = 0");
+        writer.AppendLine("ZeroValue = 0");
+        writer.AppendLine("NullableFloatValue = inf");
+        writer.Flush();
+
+        Should.Throw<OverflowException>(() =>
+            CsTomlSerializer.Deserialize<TypeDecimal>(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void RoundTrip_KeepsShortestRoundTripDigits()
+    {
+        var original = new TypeDecimal()
+        {
+            IntegerValue = 9223372036854775807m,
+            FloatValue = 0.30000000000000004m,
+            NegativeValue = -0.01m,
+            ZeroValue = 0,
+            NullableIntegerValue = -9223372036854775808m,
+            NullableFloatValue = 0.0000000000000000000000000001m,
+        };
+
+        using var bytes = CsTomlSerializer.Serialize(original);
+        var result = CsTomlSerializer.Deserialize<TypeDecimal>(bytes.ByteSpan);
+
+        result.IntegerValue.ShouldBe(original.IntegerValue);
+        result.FloatValue.ShouldBe(original.FloatValue);
+        result.NegativeValue.ShouldBe(original.NegativeValue);
+        result.ZeroValue.ShouldBe(original.ZeroValue);
+        result.NullableIntegerValue.ShouldBe(original.NullableIntegerValue);
+        result.NullableFloatValue.ShouldBe(original.NullableFloatValue);
     }
 }

--- a/tests/CsToml.Tests/DecimalConversionTest.cs
+++ b/tests/CsToml.Tests/DecimalConversionTest.cs
@@ -1,0 +1,180 @@
+﻿using System.Globalization;
+using System.Text;
+
+namespace CsToml.Tests;
+
+public class DecimalConversionTest
+{
+    private static decimal GetDecimal(string tomlValue)
+        => Deserialize(tomlValue).RootNode["v"].GetValue<decimal>();
+
+    private static decimal? GetNullableDecimal(string tomlValue)
+        => Deserialize(tomlValue).RootNode["v"].GetValue<decimal?>();
+
+    private static TomlDocument Deserialize(string tomlValue)
+        => CsTomlSerializer.Deserialize<TomlDocument>(Encoding.UTF8.GetBytes($"v = {tomlValue}\n"));
+
+    [Theory]
+    [InlineData("3.14", "3.14")]
+    [InlineData("-123.456", "-123.456")]
+    [InlineData("-0.01", "-0.01")]
+    [InlineData("-2E-2", "-0.02")]
+    [InlineData("+1.0", "1")]
+    [InlineData("1.5", "1.5")]
+    [InlineData("224_617.445_991_228", "224617.445991228")]
+    [InlineData("6.626e-3", "0.006626")]
+    [InlineData("1e10", "10000000000")]
+    [InlineData("5e+22", "50000000000000000000000")]
+    public void Float_PreservesTextDigits(string tomlValue, string expected)
+    {
+        GetDecimal(tomlValue).ToString(CultureInfo.InvariantCulture).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("0.30000000000000004", "0.30000000000000004")]
+    [InlineData("9223372036854775808.0", "9223372036854776000")]
+    [InlineData("1.2345678901234567e+25", "12345678901234566000000000")]
+    public void Float_KeepsShortestRoundTripDigits(string tomlValue, string expected)
+    {
+        // The shortest round-trippable form of the parsed double is what reaches decimal,
+        // so digits beyond the 15 significant digits of the old cast are retained.
+        GetDecimal(tomlValue).ToString(CultureInfo.InvariantCulture).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("9223372036854775807", "9223372036854775807")]
+    [InlineData("-9223372036854775808", "-9223372036854775808")]
+    [InlineData("999999", "999999")]
+    [InlineData("0", "0")]
+    [InlineData("-1", "-1")]
+    [InlineData("1_000_000", "1000000")]
+    [InlineData("0xDEADBEEF", "3735928559")]
+    [InlineData("0o755", "493")]
+    [InlineData("0b1101", "13")]
+    public void Integer_IsExact(string tomlValue, string expected)
+    {
+        // long.MaxValue is not representable as double, so a double round-trip would lose precision.
+        GetDecimal(tomlValue).ToString(CultureInfo.InvariantCulture).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("0.0")]
+    [InlineData("-0.0")]
+    [InlineData("+0.0")]
+    [InlineData("6.626e-34")]
+    [InlineData("1e-300")]
+    public void Float_ZeroOrUnderflow_IsZero(string tomlValue)
+    {
+        GetDecimal(tomlValue).ShouldBe(0m);
+    }
+
+    [Fact]
+    public void Float_SmallestDecimalStep()
+    {
+        GetDecimal("1e-28").ShouldBe(0.0000000000000000000000000001m);
+    }
+
+    [Fact]
+    public void Float_NearDecimalMaxValue()
+    {
+        GetDecimal("7.9e28").ShouldBe(79000000000000000000000000000m);
+    }
+
+    [Theory]
+    [InlineData("1e+29")]
+    [InlineData("1.7976931348623157e+308")]
+    public void Float_ExceedsDecimalRange_ThrowsOverflowException(string tomlValue)
+    {
+        Should.Throw<OverflowException>(() => GetDecimal(tomlValue));
+    }
+
+    [Theory]
+    [InlineData("inf")]
+    [InlineData("+inf")]
+    [InlineData("-inf")]
+    [InlineData("nan")]
+    [InlineData("+nan")]
+    [InlineData("-nan")]
+    public void Float_SpecialValue_ThrowsOverflowException(string tomlValue)
+    {
+        Should.Throw<OverflowException>(() => GetDecimal(tomlValue));
+    }
+
+    [Theory]
+    [InlineData("3.14")]
+    [InlineData("-123.456")]
+    [InlineData("0.30000000000000004")]
+    [InlineData("9223372036854775808.0")]
+    [InlineData("9223372036854775807")]
+    [InlineData("-9223372036854775808")]
+    [InlineData("0")]
+    [InlineData("1e-28")]
+    public void Nullable_ProducesSameValueAsNonNullable(string tomlValue)
+    {
+        GetNullableDecimal(tomlValue).ShouldBe(GetDecimal(tomlValue));
+    }
+
+    [Theory]
+    [InlineData("inf")]
+    [InlineData("nan")]
+    [InlineData("1e+29")]
+    public void Nullable_InvalidValue_ThrowsOverflowException(string tomlValue)
+    {
+        Should.Throw<OverflowException>(() => GetNullableDecimal(tomlValue));
+    }
+
+    [Fact]
+    public void Nullable_MissingKey_ReturnsNull()
+    {
+        var document = CsTomlSerializer.Deserialize<TomlDocument>("v = 1.5"u8);
+        document.RootNode["missing"].GetValue<decimal?>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void Conversion_IsCultureInvariant()
+    {
+        // A culture using ',' as the decimal separator would break a culture-sensitive
+        // format/parse round-trip inside the formatter.
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            GetDecimal("3.14").ShouldBe(3.14m);
+            GetDecimal("-123.456").ShouldBe(-123.456m);
+            GetDecimal("0.30000000000000004").ToString(CultureInfo.InvariantCulture).ShouldBe("0.30000000000000004");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Theory]
+    [InlineData("3.14")]
+    [InlineData("-99.99")]
+    [InlineData("0.0000000000000000000000000001")]
+    [InlineData("0.30000000000000004")]
+    public void RoundTrip_FloatValue(string literal)
+    {
+        var value = decimal.Parse(literal, NumberStyles.Float, CultureInfo.InvariantCulture);
+        RoundTrip(value).ShouldBe(value);
+    }
+
+    [Theory]
+    [InlineData(long.MaxValue)]
+    [InlineData(long.MinValue)]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public void RoundTrip_IntegerValue(long value)
+    {
+        RoundTrip(value).ShouldBe(value);
+    }
+
+    private static decimal RoundTrip(decimal value)
+    {
+        var dict = new Dictionary<string, decimal>() { ["v"] = value };
+        using var serialized = CsTomlSerializer.Serialize(dict);
+        var document = CsTomlSerializer.Deserialize<TomlDocument>(serialized.ByteSpan);
+        return document.RootNode["v"].GetValue<decimal>();
+    }
+}


### PR DESCRIPTION
This PR changes the conversion logic in `DecimalFormatter` and switch to use `m` suffix (`decimal` literal) decimal from/to floating-point in test case.
The main reason for this change is bug fix(`Fix decimal to/from floating-point conversions to round correctly`) in .NET 11 preview 7. Since this change fixes decimal to/from floating-point conversions to round correctly, the behavior of `(decimal)doubleValue` is different from before. Therefore, I have implemented to ensure compatibility with .NET 11 preview 7.

Changed:
- [Breaking changed] Change From `(decimal)doubleValue` to `double` -> `Span<byte>` → `decimal(Utf8Parser.TryParse)` in `DecimalFormatter.Deserialize`
- Use From `(decimal)doubleValue` to `m` suffix (`decimal` literal)